### PR TITLE
feat: add GET /api/markets with live BTC price from Bybit

### DIFF
--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -1,21 +1,50 @@
-// src/main/java/com/pms/backend/controller/MarketController.java
+package com.pms.backend.controller;
 
-package main.java.com.pms.backend.controller;
-
+import com.pms.backend.service.BybitApiService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @RestController
+@RequestMapping("/api")
 public class MarketController {
 
+    private final BybitApiService bybitApiService;
+
+    public MarketController(BybitApiService bybitApiService) {
+        this.bybitApiService = bybitApiService;
+    }
+
+    /**
+     * GET /api/markets
+     * Returns active prediction markets.
+     * MVP scope: only BTC 5-minute UP/DOWN market.
+     */
     @GetMapping("/markets")
-    public List<String> getMarkets() {
-        return List.of(
-            "Will BTC reach 100k?",
-            "Will AI replace devs?",
-            "Will Estonia GDP grow?"
+    public ResponseEntity<?> getMarkets() {
+        Double currentPrice = bybitApiService.marketOrderPrice();
+
+        if (currentPrice == null) {
+            return ResponseEntity.status(500).body("Failed to fetch BTC price");
+        }
+
+        Map<String, Object> btcMarket = Map.of(
+            "id", 1,
+            "title", "BTC 5 Minute UP or DOWN",
+            "pair", bybitApiService.marketPair(),
+            "startingPrice", currentPrice,
+            "startingDate", LocalDateTime.now().toString(),
+            "endingDate", LocalDateTime.now().plusMinutes(5).toString(),
+            "status", "OPEN",
+            "yesProbability", 50.0,
+            "noProbability", 50.0
         );
+
+        return ResponseEntity.ok(List.of(btcMarket));
     }
 }


### PR DESCRIPTION
## What
Add GET /api/markets endpoint that returns live BTC 5min UP/DOWN market.

## Why
Frontend needs a markets endpoint to display active prediction markets.

## Changes
- MarketController.java — GET /api/markets with live BTC price from Bybit

## Test
GET /api/markets returns:
- title: BTC 5 Minute UP or DOWN
- startingPrice: live BTC price from Bybit
- status: OPEN
- yesProbability: 50.0
- noProbability: 50.0

Closes #15