### PR TITLE
feat: add PostgreSQL setup with Docker Compose and JPA config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+BYBIT_API_KEY=your_bybit_api_key
+BYBIT_API_SECRET=your_bybit_api_secret
+
+DB_NAME=pms
+DB_USERNAME=your_db_username
+DB_PASSWORD=your_db_password
+DB_URL=jdbc:postgresql://localhost:5433/pms

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ backend/*.log
 # Misc
 # ========================
 coverage/
+
+backend/src/main/resources/application.properties

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ logs/
 
 # Environment
 .env
-.env.*
 
 # ========================
 # FRONTEND (Node / React)

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,54 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.4</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.pms</groupId>
-	<artifactId>backend</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name/>
-	<description/>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc</artifactId>
-		</dependency>
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>4.0.4</version>
+                <relativePath/>
+        </parent>
+        <groupId>com.pms</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <name/>
+        <description/>
+        <url/>
+        <licenses>
+                <license/>
+        </licenses>
+        <developers>
+                <developer/>
+        </developers>
+        <scm>
+                <connection/>
+                <developerConnection/>
+                <tag/>
+                <url/>
+        </scm>
+        <properties>
+                <java.version>21</java.version>
+        </properties>
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-webmvc</artifactId>
+                </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <!-- JPA -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+                <!-- PostgreSQL -->
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
 
+                <!-- dotenv - reads .env file -->
+                <dependency>
+                        <groupId>me.paulschwarz</groupId>
+                        <artifactId>spring-dotenv</artifactId>
+                        <version>4.0.0</version>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-webmvc-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/backend/src/main/java/com/pms/backend/model/MarketType.java
+++ b/backend/src/main/java/com/pms/backend/model/MarketType.java
@@ -1,0 +1,48 @@
+package com.pms.backend.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * MarketType - defines the type of market supported by the system.
+ *
+ * Fields based on architecture diagram:
+ *   - ticker:      trading pair symbol (e.g. BTCUSDT)
+ *   - api:         external API source identifier (e.g. "bybit")
+ *   - enabled:     whether this market type is active
+ *   - createDate:  when this market type was registered
+ *
+ * MVP scope: only BTC 5-minute UP/DOWN market type is active.
+ */
+public class MarketType {
+
+    private Long id;
+    private String ticker;
+    private String api;
+    private boolean enabled;
+    private LocalDateTime createDate;
+
+    public MarketType() {}
+
+    public MarketType(Long id, String ticker, String api, boolean enabled, LocalDateTime createDate) {
+        this.id = id;
+        this.ticker = ticker;
+        this.api = api;
+        this.enabled = enabled;
+        this.createDate = createDate;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getTicker() { return ticker; }
+    public void setTicker(String ticker) { this.ticker = ticker; }
+
+    public String getApi() { return api; }
+    public void setApi(String api) { this.api = api; }
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public LocalDateTime getCreateDate() { return createDate; }
+    public void setCreateDate(LocalDateTime createDate) { this.createDate = createDate; }
+}

--- a/backend/src/main/java/com/pms/backend/service/BybitApiService.java
+++ b/backend/src/main/java/com/pms/backend/service/BybitApiService.java
@@ -1,0 +1,100 @@
+package com.pms.backend.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * BybitApiService - fetches live BTC price data from Bybit public API.
+ *
+ * Endpoints used:
+ *   GET /v5/market/tickers?category=spot&symbol=BTCUSDT
+ *
+ * To use real API key (private endpoints), set in application.properties:
+ *   bybit.api.key=YOUR_API_KEY_HERE
+ *   bybit.api.secret=YOUR_API_SECRET_HERE
+ *
+ * For MVP, only public endpoints are used — no API key required.
+ */
+@Service
+public class BybitApiService {
+
+    private static final String BYBIT_BASE_URL = "https://api.bybit.com";
+    private static final String SYMBOL = "BTCUSDT";
+
+    // Add your API key to application.properties if needed for private endpoints
+    @Value("${bybit.api.key:}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate;
+
+    public BybitApiService() {
+        this.restTemplate = new RestTemplate();
+    }
+
+    /**
+     * market_pair(BTC) - Returns the trading pair symbol used for this market.
+     * Currently fixed to BTCUSDT as per MVP scope.
+     */
+    public String marketPair() {
+        return SYMBOL;
+    }
+
+    /**
+     * market_orders(price) - Fetches the current last traded price for BTCUSDT.
+     * Uses Bybit public spot ticker endpoint.
+     *
+     * @return current BTC price as Double, or null if fetch fails
+     */
+    public Double marketOrderPrice() {
+        try {
+            String url = BYBIT_BASE_URL + "/v5/market/tickers?category=spot&symbol=" + SYMBOL;
+            BybitTickerResponse response = restTemplate.getForObject(url, BybitTickerResponse.class);
+
+            if (response != null
+                    && response.getResult() != null
+                    && response.getResult().getList() != null
+                    && !response.getResult().getList().isEmpty()) {
+
+                String lastPrice = response.getResult().getList().get(0).getLastPrice();
+                return Double.parseDouble(lastPrice);
+            }
+        } catch (Exception e) {
+            // Log and return null — caller handles fallback
+            System.err.println("BybitApiService: Failed to fetch BTC price: " + e.getMessage());
+        }
+        return null;
+    }
+
+    // --- Inner classes for JSON mapping ---
+
+    static class BybitTickerResponse {
+        private int retCode;
+        private String retMsg;
+        private Result result;
+
+        public int getRetCode() { return retCode; }
+        public void setRetCode(int retCode) { this.retCode = retCode; }
+        public String getRetMsg() { return retMsg; }
+        public void setRetMsg(String retMsg) { this.retMsg = retMsg; }
+        public Result getResult() { return result; }
+        public void setResult(Result result) { this.result = result; }
+
+        static class Result {
+            private java.util.List<Ticker> list;
+
+            public java.util.List<Ticker> getList() { return list; }
+            public void setList(java.util.List<Ticker> list) { this.list = list; }
+        }
+
+        static class Ticker {
+            private String symbol;
+            private String lastPrice;
+
+            public String getSymbol() { return symbol; }
+            public void setSymbol(String symbol) { this.symbol = symbol; }
+            public String getLastPrice() { return lastPrice; }
+            public void setLastPrice(String lastPrice) { this.lastPrice = lastPrice; }
+        }
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=backend

--- a/backend/src/main/resources/application.properties.example
+++ b/backend/src/main/resources/application.properties.example
@@ -1,0 +1,15 @@
+spring.application.name=backend
+
+# Database
+spring.datasource.url=jdbc:postgresql://localhost:5433/pms
+spring.datasource.username=your_db_username
+spring.datasource.password=your_db_password
+
+# JPA
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# Bybit API
+bybit.api.key=your_bybit_api_key
+bybit.api.secret=your_bybit_api_secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  db:
+    image: postgres:16
+    container_name: pms-postgres
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## What
Set up PostgreSQL database with Docker Compose and configure Spring Boot JPA connection.

## Why
Backend needs a persistent database to store markets and positions.

## Changes
- docker-compose.yml - PostgreSQL 16 on port 5433
- backend/pom.xml - added JPA and PostgreSQL dependencies
- application.properties.example - team onboarding template
- .env.example - local setup template
- .gitignore - application.properties excluded from Git

## Test
docker-compose up -d
mvn spring-boot:run
HikariPool connects to PostgreSQL successfully

Closes #19