### PR TITLE
feat(be): add JPA entities and repositories for market persistence

### DIFF
--- a/backend/src/main/java/com/pms/backend/model/Market.java
+++ b/backend/src/main/java/com/pms/backend/model/Market.java
@@ -1,0 +1,66 @@
+package com.pms.backend.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "markets")
+public class Market {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private Double startingPrice;
+
+    @Column(nullable = false)
+    private LocalDateTime startingDate;
+
+    @Column(nullable = false)
+    private LocalDateTime endingDate;
+
+    @Column(nullable = false)
+    private String status;
+
+    @Column(nullable = true)
+    private String result;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "market_type_id", nullable = false)
+    private MarketType marketType;
+
+    public Market() {}
+
+    public Long getId() { return id; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public Double getStartingPrice() { return startingPrice; }
+    public void setStartingPrice(Double startingPrice) { this.startingPrice = startingPrice; }
+
+    public LocalDateTime getStartingDate() { return startingDate; }
+    public void setStartingDate(LocalDateTime startingDate) { this.startingDate = startingDate; }
+
+    public LocalDateTime getEndingDate() { return endingDate; }
+    public void setEndingDate(LocalDateTime endingDate) { this.endingDate = endingDate; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getResult() { return result; }
+    public void setResult(String result) { this.result = result; }
+
+    public MarketType getMarketType() { return marketType; }
+    public void setMarketType(MarketType marketType) { this.marketType = marketType; }
+}

--- a/backend/src/main/java/com/pms/backend/model/MarketType.java
+++ b/backend/src/main/java/com/pms/backend/model/MarketType.java
@@ -1,24 +1,26 @@
 package com.pms.backend.model;
 
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
-/**
- * MarketType - defines the type of market supported by the system.
- *
- * Fields based on architecture diagram:
- *   - ticker:      trading pair symbol (e.g. BTCUSDT)
- *   - api:         external API source identifier (e.g. "bybit")
- *   - enabled:     whether this market type is active
- *   - createDate:  when this market type was registered
- *
- * MVP scope: only BTC 5-minute UP/DOWN market type is active.
- */
+@Entity
+@Table(name = "market_types")
 public class MarketType {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
     private String ticker;
+
+    @Column(nullable = false)
     private String api;
+
+    @Column(nullable = false)
     private boolean enabled;
+
+    @Column(nullable = false)
     private LocalDateTime createDate;
 
     public MarketType() {}

--- a/backend/src/main/java/com/pms/backend/model/Position.java
+++ b/backend/src/main/java/com/pms/backend/model/Position.java
@@ -1,0 +1,54 @@
+package com.pms.backend.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "positions")
+public class Position {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "market_id", nullable = false)
+    private Market market;
+
+    @Column(nullable = false)
+    private String positionType;
+
+    @Column(nullable = false)
+    private Double amount;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = true)
+    private String result;
+
+    public Position() {}
+
+    public Long getId() { return id; }
+
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+
+    public Market getMarket() { return market; }
+    public void setMarket(Market market) { this.market = market; }
+
+    public String getPositionType() { return positionType; }
+    public void setPositionType(String positionType) { this.positionType = positionType; }
+
+    public Double getAmount() { return amount; }
+    public void setAmount(Double amount) { this.amount = amount; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public String getResult() { return result; }
+    public void setResult(String result) { this.result = result; }
+}

--- a/backend/src/main/java/com/pms/backend/repository/MarketRepository.java
+++ b/backend/src/main/java/com/pms/backend/repository/MarketRepository.java
@@ -1,0 +1,7 @@
+package com.pms.backend.repository;
+
+import com.pms.backend.model.Market;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarketRepository extends JpaRepository<Market, Long> {
+}

--- a/backend/src/main/java/com/pms/backend/repository/MarketTypeRepository.java
+++ b/backend/src/main/java/com/pms/backend/repository/MarketTypeRepository.java
@@ -1,0 +1,7 @@
+package com.pms.backend.repository;
+
+import com.pms.backend.model.MarketType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarketTypeRepository extends JpaRepository<MarketType, Long> {
+}

--- a/backend/src/main/java/com/pms/backend/repository/PositionRepository.java
+++ b/backend/src/main/java/com/pms/backend/repository/PositionRepository.java
@@ -1,0 +1,10 @@
+package com.pms.backend.repository;
+
+import com.pms.backend.model.Position;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PositionRepository extends JpaRepository<Position, Long> {
+    List<Position> findByMarketId(Long marketId);
+}


### PR DESCRIPTION
Closes #23

Adds database persistence layer for markets and positions.

Includes:
- Market entity
- Position entity
- MarketType converted to JPA entity
- repositories (Market, Position, MarketType)

Validation:
- mvn clean test passed
- application starts without errors

Notes:
- no service layer changes
- no controller refactor in this PR