### PR TITLE
Feature/be market scheduler and odds

### DIFF
--- a/backend/src/main/java/com/pms/backend/BackendApplication.java
+++ b/backend/src/main/java/com/pms/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.pms.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/pms/backend/config/CorsConfig.java
+++ b/backend/src/main/java/com/pms/backend/config/CorsConfig.java
@@ -1,0 +1,17 @@
+package com.pms.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+    }
+}

--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -1,10 +1,11 @@
 package com.pms.backend.controller;
 
+import com.pms.backend.dto.MarketOdds;
 import com.pms.backend.model.Market;
 import com.pms.backend.model.Position;
 import com.pms.backend.repository.MarketRepository;
 import com.pms.backend.repository.PositionRepository;
-import com.pms.backend.service.BybitApiService;
+import com.pms.backend.service.OddsService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,80 +18,63 @@ import java.util.Optional;
 @RequestMapping("/api")
 public class MarketController {
 
-    private final BybitApiService bybitApiService;
     private final MarketRepository marketRepository;
     private final PositionRepository positionRepository;
-    private final com.pms.backend.service.PositionService positionService;
+    private final OddsService oddsService;
 
     public MarketController(
-            BybitApiService bybitApiService,
             MarketRepository marketRepository,
             PositionRepository positionRepository,
-            com.pms.backend.service.PositionService positionService
-    ) {
-        this.bybitApiService = bybitApiService;
+            OddsService oddsService) {
         this.marketRepository = marketRepository;
         this.positionRepository = positionRepository;
-        this.positionService = positionService;
+        this.oddsService = oddsService;
     }
 
     /**
      * GET /api/markets
      *
-     * Returns a single BTC prediction market (MVP scope).
+     * Returns the current (latest) BTC prediction market.
+     * Pure read — the scheduler manages market lifecycle.
      *
-     * Stable response contract for frontend integration:
+     * Response contract:
      * - id (Long)
      * - title (String)
      * - pair (String)
      * - startingPrice (Double)
+     * - endingPrice (Double)
      * - startingDate (String ISO)
      * - endingDate (String ISO)
      * - status (String: OPEN/CLOSED)
+     * - result (String: UP/DOWN/null)
      * - yesProbability (Double)
      * - noProbability (Double)
      *
-     * Notes:
-     * - Single BTC market only
-     * - Uses DB state if market exists, fallback to default otherwise
-     * - No multi-market support
+     * Returns 204 No Content if no market has been created yet.
      */
     @GetMapping("/markets")
     public ResponseEntity<?> getMarkets() {
-        Double currentPrice = bybitApiService.marketOrderPrice();
+        Optional<Market> marketOptional = marketRepository.findTopByOrderByIdDesc();
 
-        if (currentPrice == null) {
-            return ResponseEntity.status(500).body("Failed to fetch BTC price");
+        if (marketOptional.isEmpty()) {
+            return ResponseEntity.noContent().build();
         }
 
-        Optional<Market> marketOptional = marketRepository.findById(1L);
-
-        String title = "BTC 5 Minute UP or DOWN";
-        String startingDate = LocalDateTime.now().toString();
-        String endingDate = LocalDateTime.now().plusMinutes(5).toString();
-        String status = "OPEN";
-        String result = null;
-
-        if (marketOptional.isPresent()) {
-            Market market = marketOptional.get();
-            title = market.getTitle();
-            startingDate = market.getStartingDate().toString();
-            endingDate = market.getEndingDate().toString();
-            status = market.getStatus();
-            result = market.getResult();
-        }
+        Market market = marketOptional.get();
+        MarketOdds odds = oddsService.calculateOdds(market.getId());
 
         Map<String, Object> btcMarket = new java.util.LinkedHashMap<>();
-        btcMarket.put("id", 1);
-        btcMarket.put("title", title);
-        btcMarket.put("pair", bybitApiService.marketPair());
-        btcMarket.put("startingPrice", currentPrice);
-        btcMarket.put("startingDate", startingDate);
-        btcMarket.put("endingDate", endingDate);
-        btcMarket.put("status", status);
-        btcMarket.put("result", result);
-        btcMarket.put("yesProbability", 50.0);
-        btcMarket.put("noProbability", 50.0);
+        btcMarket.put("id", market.getId());
+        btcMarket.put("title", market.getTitle());
+        btcMarket.put("pair", "BTCUSDT");
+        btcMarket.put("startingPrice", market.getStartingPrice());
+        btcMarket.put("endingPrice", null);
+        btcMarket.put("startingDate", market.getStartingDate().toString());
+        btcMarket.put("endingDate", market.getEndingDate().toString());
+        btcMarket.put("status", market.getStatus());
+        btcMarket.put("result", null);
+        btcMarket.put("yesProbability", odds.upProbability());
+        btcMarket.put("noProbability", odds.downProbability());
 
         return ResponseEntity.ok(List.of(btcMarket));
     }
@@ -132,13 +116,12 @@ public class MarketController {
         Position savedPosition = positionRepository.save(position);
 
         return ResponseEntity.ok(Map.of(
-            "message", "Position created successfully",
-            "positionId", savedPosition.getId(),
-            "marketId", savedPosition.getMarket().getId(),
-            "userId", savedPosition.getUserId(),
-            "positionType", savedPosition.getPositionType(),
-            "amount", savedPosition.getAmount()
-        ));
+                "message", "Position created successfully",
+                "positionId", savedPosition.getId(),
+                "marketId", savedPosition.getMarket().getId(),
+                "userId", savedPosition.getUserId(),
+                "positionType", savedPosition.getPositionType(),
+                "amount", savedPosition.getAmount()));
     }
 
     public static class CreatePositionRequest {
@@ -181,63 +164,19 @@ public class MarketController {
     }
 
     /**
-     * POST /api/resolve
+     * GET /api/resolve
      *
-     * Resolves a BTC prediction market.
-     *
-     * Input:
-     * - marketId
-     * - result (UP/DOWN)
-     *
-     * Actions:
-     * - updates all positions (WIN/LOSS)
-     * - sets market result
-     * - sets market status to CLOSED
+     * Returns the result of the last (most recently closed) market.
+     * Read-only — no request body, no side effects.
      */
-    @PostMapping("/resolve")
-    public ResponseEntity<?> resolveMarket(@RequestBody ResolveRequest request) {
-
-        if (request.getMarketId() == null || request.getResult() == null) {
-            return ResponseEntity.badRequest().body("marketId and result are required");
-        }
-
-        String result = request.getResult().trim().toUpperCase();
-        if (!result.equals("UP") && !result.equals("DOWN")) {
-            return ResponseEntity.badRequest().body("result must be UP or DOWN");
-        }
-
-        Optional<Market> marketOptional = marketRepository.findById(request.getMarketId());
-        if (marketOptional.isEmpty()) {
-            return ResponseEntity.status(404).body("Market not found");
-        }
-
-        Market market = marketOptional.get();
-
-        // Resolve positions (WIN / LOSS)
-        positionService.resolveAllPositionsForMarket(market.getId(), result);
-
-        // Update market
-        market.setResult(result);
-        market.setStatus("CLOSED");
-
-        marketRepository.save(market);
-
-        return ResponseEntity.ok(Map.of(
-                "message", "Market resolved successfully",
-                "marketId", market.getId(),
-                "result", result,
-                "status", market.getStatus()
-        ));
-    }
-
-    public static class ResolveRequest {
-        private Long marketId;
-        private String result;
-
-        public Long getMarketId() { return marketId; }
-        public void setMarketId(Long marketId) { this.marketId = marketId; }
-
-        public String getResult() { return result; }
-        public void setResult(String result) { this.result = result; }
+    @GetMapping("/resolve")
+    public ResponseEntity<?> getLastMarketResult() {
+        return marketRepository.findTopByStatusOrderByIdDesc("CLOSED")
+                .map(market -> ResponseEntity.ok(Map.of(
+                        "marketId", market.getId(),
+                        "endingPrice", market.getEndingPrice(),
+                        "result", market.getResult() != null ? market.getResult() : "PENDING",
+                        "status", market.getStatus())))
+                .orElse(ResponseEntity.status(404).build());
     }
 }

--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -68,11 +68,11 @@ public class MarketController {
         btcMarket.put("title", market.getTitle());
         btcMarket.put("pair", "BTCUSDT");
         btcMarket.put("startingPrice", market.getStartingPrice());
-        btcMarket.put("endingPrice", null);
+        btcMarket.put("endingPrice", market.getEndingPrice());
         btcMarket.put("startingDate", market.getStartingDate().toString());
         btcMarket.put("endingDate", market.getEndingDate().toString());
         btcMarket.put("status", market.getStatus());
-        btcMarket.put("result", null);
+        btcMarket.put("result", market.getResult());
         btcMarket.put("yesProbability", odds.upProbability());
         btcMarket.put("noProbability", odds.downProbability());
 
@@ -106,9 +106,15 @@ public class MarketController {
             return ResponseEntity.status(404).body("Market not found");
         }
 
+        Market market = marketOptional.get();
+
+        if (!"OPEN".equals(market.getStatus())) {
+            return ResponseEntity.badRequest().body("Market is not open");
+        }
+
         Position position = new Position();
         position.setUserId(request.getUserId());
-        position.setMarket(marketOptional.get());
+        position.setMarket(market);
         position.setPositionType(positionType);
         position.setAmount(request.getAmount());
         position.setCreatedAt(LocalDateTime.now());

--- a/backend/src/main/java/com/pms/backend/dto/MarketOdds.java
+++ b/backend/src/main/java/com/pms/backend/dto/MarketOdds.java
@@ -1,0 +1,7 @@
+package com.pms.backend.dto;
+
+/**
+ * Immutable container for calculated market probabilities.
+ * Values are percentages (0–100) that always sum to 100.
+ */
+public record MarketOdds(double upProbability, double downProbability) {}

--- a/backend/src/main/java/com/pms/backend/model/Market.java
+++ b/backend/src/main/java/com/pms/backend/model/Market.java
@@ -32,35 +32,89 @@ public class Market {
     @Column(nullable = true)
     private String result;
 
+    @Column(nullable = false)
+    private Double endingPrice;
+
     @ManyToOne(optional = false)
     @JoinColumn(name = "market_type_id", nullable = false)
     private MarketType marketType;
 
-    public Market() {}
+    public Market() {
+    }
 
-    public Long getId() { return id; }
+    public Long getId() {
+        return id;
+    }
 
-    public String getTitle() { return title; }
-    public void setTitle(String title) { this.title = title; }
+    public String getTitle() {
+        return title;
+    }
 
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+    public void setTitle(String title) {
+        this.title = title;
+    }
 
-    public Double getStartingPrice() { return startingPrice; }
-    public void setStartingPrice(Double startingPrice) { this.startingPrice = startingPrice; }
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
 
-    public LocalDateTime getStartingDate() { return startingDate; }
-    public void setStartingDate(LocalDateTime startingDate) { this.startingDate = startingDate; }
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
 
-    public LocalDateTime getEndingDate() { return endingDate; }
-    public void setEndingDate(LocalDateTime endingDate) { this.endingDate = endingDate; }
+    public Double getStartingPrice() {
+        return startingPrice;
+    }
 
-    public String getStatus() { return status; }
-    public void setStatus(String status) { this.status = status; }
+    public void setStartingPrice(Double startingPrice) {
+        this.startingPrice = startingPrice;
+    }
 
-    public String getResult() { return result; }
-    public void setResult(String result) { this.result = result; }
+    public LocalDateTime getStartingDate() {
+        return startingDate;
+    }
 
-    public MarketType getMarketType() { return marketType; }
-    public void setMarketType(MarketType marketType) { this.marketType = marketType; }
+    public void setStartingDate(LocalDateTime startingDate) {
+        this.startingDate = startingDate;
+    }
+
+    public LocalDateTime getEndingDate() {
+        return endingDate;
+    }
+
+    public void setEndingDate(LocalDateTime endingDate) {
+        this.endingDate = endingDate;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    public Double getEndingPrice() {
+        return endingPrice;
+    }
+
+    public void setEndingPrice(Double endingPrice) {
+        this.endingPrice = endingPrice;
+    }
+
+    public MarketType getMarketType() {
+        return marketType;
+    }
+
+    public void setMarketType(MarketType marketType) {
+        this.marketType = marketType;
+    }
 }

--- a/backend/src/main/java/com/pms/backend/repository/MarketRepository.java
+++ b/backend/src/main/java/com/pms/backend/repository/MarketRepository.java
@@ -3,5 +3,12 @@ package com.pms.backend.repository;
 import com.pms.backend.model.Market;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MarketRepository extends JpaRepository<Market, Long> {
+    Optional<Market> findTopByOrderByIdDesc();
+
+    Optional<Market> findByStatus(String status);
+
+    Optional<Market> findTopByStatusOrderByIdDesc(String status);
 }

--- a/backend/src/main/java/com/pms/backend/service/MarketScheduler.java
+++ b/backend/src/main/java/com/pms/backend/service/MarketScheduler.java
@@ -1,0 +1,139 @@
+package com.pms.backend.service;
+
+import com.pms.backend.model.Market;
+import com.pms.backend.model.MarketType;
+import com.pms.backend.repository.MarketRepository;
+import com.pms.backend.repository.MarketTypeRepository;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+/**
+ * Manages the 5-minute market lifecycle.
+ *
+ * On each tick (every 5 minutes, aligned to clock):
+ *   1. Close the current OPEN market (fetch endingPrice, determine result, resolve positions)
+ *   2. Open a new market (fetch startingPrice, set 5-min window)
+ *
+ * Also runs once on startup via @EventListener(ApplicationReadyEvent) to avoid waiting for the first tick.
+ *
+ * If the Bybit API is down:
+ *   - Close the current market using startingPrice as fallback endingPrice
+ *   - Do NOT open a new market (next successful tick will open one)
+ */
+@Service
+public class MarketScheduler {
+
+    private final MarketRepository marketRepository;
+    private final MarketTypeRepository marketTypeRepository;
+    private final BybitApiService bybitApiService;
+    private final PositionService positionService;
+
+    public MarketScheduler(
+            MarketRepository marketRepository,
+            MarketTypeRepository marketTypeRepository,
+            BybitApiService bybitApiService,
+            PositionService positionService) {
+        this.marketRepository = marketRepository;
+        this.marketTypeRepository = marketTypeRepository;
+        this.bybitApiService = bybitApiService;
+        this.positionService = positionService;
+    }
+
+    /**
+     * Runs once after the entire application context is ready (including data.sql).
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void onStartup() {
+        tick();
+    }
+
+    /**
+     * Runs every 5 minutes on clock boundaries: :00, :05, :10, :15, ...
+     */
+    @Scheduled(cron = "0 0/5 * * * *")
+    public void tick() {
+        System.out.println("[MarketScheduler] Tick at " + LocalDateTime.now());
+
+        // 1. Close the current OPEN market (if any)
+        closeCurrentMarket();
+
+        // 2. Open a new market
+        openNewMarket();
+    }
+
+    private void closeCurrentMarket() {
+        Optional<Market> openMarket = marketRepository.findByStatus("OPEN");
+        if (openMarket.isEmpty()) {
+            System.out.println("[MarketScheduler] No OPEN market to close.");
+            return;
+        }
+
+        Market market = openMarket.get();
+
+        // Fetch ending price — fall back to startingPrice if Bybit is down
+        Double endingPrice = bybitApiService.marketOrderPrice();
+        if (endingPrice == null) {
+            System.err.println("[MarketScheduler] Bybit API down — closing with startingPrice as fallback.");
+            endingPrice = market.getStartingPrice();
+        }
+
+        // Determine result
+        String result = endingPrice >= market.getStartingPrice() ? "UP" : "DOWN";
+
+        // Update market
+        market.setEndingPrice(endingPrice);
+        market.setResult(result);
+        market.setStatus("CLOSED");
+        marketRepository.save(market);
+
+        // Resolve all positions
+        positionService.resolveAllPositionsForMarket(market.getId(), result);
+
+        System.out.println("[MarketScheduler] Closed market #" + market.getId()
+                + " | start=" + market.getStartingPrice()
+                + " end=" + endingPrice
+                + " result=" + result);
+    }
+
+    private void openNewMarket() {
+        Double startingPrice = bybitApiService.marketOrderPrice();
+        if (startingPrice == null) {
+            System.err.println("[MarketScheduler] Bybit API down — skipping new market creation.");
+            return;
+        }
+
+        // Find the default MarketType (seeded by data.sql)
+        MarketType marketType = marketTypeRepository.findById(1L)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Default MarketType (id=1) not found. Ensure data.sql has run."));
+
+        LocalDateTime now = LocalDateTime.now();
+        // Align to the current 5-minute boundary
+        LocalDateTime startingDate = now.truncatedTo(ChronoUnit.HOURS)
+                .plusMinutes((now.getMinute() / 5) * 5L);
+        LocalDateTime endingDate = startingDate.plusMinutes(5);
+
+        Market market = new Market();
+        market.setTitle("BTC 5 Minute UP or DOWN");
+        market.setCreatedAt(now);
+        market.setStartingPrice(startingPrice);
+        market.setEndingPrice(startingPrice); // placeholder — updated on close
+        market.setStartingDate(startingDate);
+        market.setEndingDate(endingDate);
+        market.setStatus("OPEN");
+        market.setResult(null);
+        market.setMarketType(marketType);
+
+        Market saved = marketRepository.save(market);
+
+        System.out.println("[MarketScheduler] Opened market #" + saved.getId()
+                + " | price=" + startingPrice
+                + " window=" + startingDate + " → " + endingDate);
+    }
+}

--- a/backend/src/main/java/com/pms/backend/service/OddsService.java
+++ b/backend/src/main/java/com/pms/backend/service/OddsService.java
@@ -1,0 +1,56 @@
+package com.pms.backend.service;
+
+import com.pms.backend.dto.MarketOdds;
+import com.pms.backend.model.Position;
+import com.pms.backend.repository.PositionRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Calculates live UP/DOWN probability for a market based on
+ * the ratio of placed positions (weighted by amount).
+ *
+ * Pure read-only service — no side effects, no persistence.
+ */
+@Service
+public class OddsService {
+
+    private final PositionRepository positionRepository;
+
+    public OddsService(PositionRepository positionRepository) {
+        this.positionRepository = positionRepository;
+    }
+
+    /**
+     * Computes the UP/DOWN probability split for the given market.
+     *
+     * @param marketId the market to calculate odds for
+     * @return MarketOdds with upProbability and downProbability (0–100),
+     *         defaults to 50/50 when no positions exist
+     */
+    public MarketOdds calculateOdds(Long marketId) {
+        List<Position> positions = positionRepository.findByMarketId(marketId);
+
+        double totalUp = 0.0;
+        double totalDown = 0.0;
+
+        for (Position p : positions) {
+            if ("UP".equals(p.getPositionType())) {
+                totalUp += p.getAmount();
+            } else {
+                totalDown += p.getAmount();
+            }
+        }
+
+        double total = totalUp + totalDown;
+
+        if (total == 0) {
+            return new MarketOdds(50.0, 50.0);
+        }
+
+        return new MarketOdds(
+                (totalUp / total) * 100.0,
+                (totalDown / total) * 100.0);
+    }
+}

--- a/backend/src/main/resources/application.properties.example
+++ b/backend/src/main/resources/application.properties.example
@@ -9,6 +9,8 @@ spring.datasource.password=your_db_password
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=always
 
 # Bybit API
 bybit.api.key=your_bybit_api_key

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,0 +1,4 @@
+-- Seed a default MarketType for BTCUSDT (required by MarketScheduler)
+INSERT INTO market_types (id, ticker, api, enabled, create_date)
+VALUES (1, 'BTCUSDT', 'bybit', true, NOW())
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Added a new mandatory `endingPrice` column to the Market database table, you'll need to drop your old database tables and let Hibernate recreate them, otherwise the app will crash on startup.

A new MarketScheduler runs in the background. Every 5 minutes (:00, :05, :10), it automatically closes the current market, checks the final BTC price to declare UP or DOWN and opens a brand new market for the next 5 minutes.

`MarketController` is much simpler. It just reads the latest data straight from the DB.

Added global CORS config so the Vite dev server can talk to backend