### PR TITLE
feat(wallet): add starter claim flow and balance deduction for positions

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -35,6 +35,11 @@
                         <artifactId>spring-boot-starter-webmvc</artifactId>
                 </dependency>
 
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
+
                 <!-- JPA -->
                 <dependency>
                         <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/pms/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pms/backend/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
                                 "/api/markets",
                                 "/api/resolve"
                         ).permitAll()
-                        .requestMatchers("/api/position").permitAll()
+                        .requestMatchers("/api/position").authenticated()
                         .anyRequest().permitAll()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/backend/src/main/java/com/pms/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pms/backend/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.pms.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/api/markets",
+                                "/api/resolve"
+                        ).permitAll()
+                        .requestMatchers("/api/position").authenticated()
+                        .anyRequest().permitAll()
+                )
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .logout(logout -> logout
+                        .logoutUrl("/api/auth/logout")
+                        .invalidateHttpSession(true)
+                        .deleteCookies("JSESSIONID")
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/pms/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pms/backend/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.pms.backend.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -24,7 +23,7 @@ public class SecurityConfig {
                                 "/api/markets",
                                 "/api/resolve"
                         ).permitAll()
-                        .requestMatchers("/api/position").authenticated()
+                        .requestMatchers("/api/position").permitAll()
                         .anyRequest().permitAll()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/backend/src/main/java/com/pms/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/pms/backend/controller/AuthController.java
@@ -8,6 +8,9 @@ import com.pms.backend.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -48,6 +51,14 @@ public class AuthController {
 
         HttpSession session = httpRequest.getSession(true);
         session.setAttribute("USER_ID", user.getId());
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(user.getEmail(), null, java.util.List.of());
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+        session.setAttribute("SPRING_SECURITY_CONTEXT", context);
 
         return ResponseEntity.ok(authService.toResponse(user));
     }

--- a/backend/src/main/java/com/pms/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/pms/backend/controller/AuthController.java
@@ -1,0 +1,78 @@
+package com.pms.backend.controller;
+
+import com.pms.backend.dto.AuthUserResponse;
+import com.pms.backend.dto.LoginRequest;
+import com.pms.backend.dto.RegisterRequest;
+import com.pms.backend.model.User;
+import com.pms.backend.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody RegisterRequest request) {
+        try {
+            AuthUserResponse user = authService.register(request);
+            return ResponseEntity.ok(user);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(
+            @RequestBody LoginRequest request,
+            HttpServletRequest httpRequest
+    ) {
+        if (request.getEmail() == null || request.getPassword() == null) {
+            return ResponseEntity.badRequest().body("email and password are required");
+        }
+
+        User user = authService.findByEmail(request.getEmail());
+        if (user == null || !authService.passwordMatches(request.getPassword(), user.getPasswordHash())) {
+            return ResponseEntity.status(401).body("Invalid credentials");
+        }
+
+        HttpSession session = httpRequest.getSession(true);
+        session.setAttribute("USER_ID", user.getId());
+
+        return ResponseEntity.ok(authService.toResponse(user));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> me(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session == null || session.getAttribute("USER_ID") == null) {
+            return ResponseEntity.status(401).body("Not authenticated");
+        }
+
+        Long userId = (Long) session.getAttribute("USER_ID");
+
+        return ResponseEntity.ok(Map.of("userId", userId));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session != null) {
+            session.invalidate();
+        }
+
+        return ResponseEntity.ok("Logged out");
+    }
+}

--- a/backend/src/main/java/com/pms/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/pms/backend/controller/AuthController.java
@@ -72,8 +72,17 @@ public class AuthController {
         }
 
         Long userId = (Long) session.getAttribute("USER_ID");
+        User user = authService.findById(userId);
 
-        return ResponseEntity.ok(Map.of("userId", userId));
+        if (user == null) {
+            return ResponseEntity.status(404).body("User not found");
+        }
+
+        return ResponseEntity.ok(Map.of(
+                "userId", user.getId(),
+                "balance", user.getBalance(),
+                "starterClaimed", user.isStarterClaimed()
+        ));
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -1,6 +1,5 @@
 package com.pms.backend.controller;
 
-import com.pms.backend.controller.MarketController.CreatePositionRequest;
 import com.pms.backend.dto.MarketOdds;
 import com.pms.backend.model.Market;
 import com.pms.backend.model.Position;
@@ -139,6 +138,35 @@ public class MarketController {
                 "userId", savedPosition.getUserId(),
                 "positionType", savedPosition.getPositionType(),
                 "amount", savedPosition.getAmount()));
+    }
+
+    /**
+     * GET /api/positions/me
+     * Returns all positions for the authenticated user.
+     */
+    @GetMapping("/positions/me")
+    public ResponseEntity<?> getMyPositions(HttpServletRequest httpRequest) {
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("USER_ID") == null) {
+            return ResponseEntity.status(401).body("Not authenticated");
+        }
+
+        Long authenticatedUserId = (Long) session.getAttribute("USER_ID");
+
+        List<Map<String, Object>> positions = positionRepository
+                .findByUserIdOrderByCreatedAtDesc(authenticatedUserId)
+                .stream()
+                .map(position -> Map.<String, Object>of(
+                        "positionId", position.getId(),
+                        "marketId", position.getMarket().getId(),
+                        "userId", position.getUserId(),
+                        "positionType", position.getPositionType(),
+                        "amount", position.getAmount(),
+                        "createdAt", position.getCreatedAt().toString()
+                ))
+                .toList();
+
+        return ResponseEntity.ok(positions);
     }
 
     public static class CreatePositionRequest {

--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -14,7 +14,6 @@ import jakarta.servlet.http.HttpSession;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;

--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -3,8 +3,10 @@ package com.pms.backend.controller;
 import com.pms.backend.dto.MarketOdds;
 import com.pms.backend.model.Market;
 import com.pms.backend.model.Position;
+import com.pms.backend.model.User;
 import com.pms.backend.repository.MarketRepository;
 import com.pms.backend.repository.PositionRepository;
+import com.pms.backend.service.AuthService;
 import com.pms.backend.service.OddsService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -23,14 +25,17 @@ public class MarketController {
     private final MarketRepository marketRepository;
     private final PositionRepository positionRepository;
     private final OddsService oddsService;
+    private final AuthService authService;
 
     public MarketController(
             MarketRepository marketRepository,
             PositionRepository positionRepository,
-            OddsService oddsService) {
+            OddsService oddsService,
+            AuthService authService) {
         this.marketRepository = marketRepository;
         this.positionRepository = positionRepository;
         this.oddsService = oddsService;
+        this.authService = authService;
     }
 
     /**
@@ -96,6 +101,12 @@ public class MarketController {
         }
 
         Long authenticatedUserId = (Long) session.getAttribute("USER_ID");
+        User user = authService.findById(authenticatedUserId);
+
+        if (user == null) {
+            return ResponseEntity.status(404).body("User not found");
+        }        
+
         if (request.getMarketId() == null ||
                 request.getPositionType() == null ||
                 request.getAmount() == null) {
@@ -109,6 +120,10 @@ public class MarketController {
 
         if (request.getAmount() <= 0) {
             return ResponseEntity.badRequest().body("amount must be greater than 0");
+        }
+
+        if (user.getBalance() < request.getAmount()) {
+            return ResponseEntity.badRequest().body("Insufficient balance");
         }
 
         Optional<Market> marketOptional = marketRepository.findById(request.getMarketId());
@@ -129,6 +144,9 @@ public class MarketController {
         position.setAmount(request.getAmount());
         position.setCreatedAt(LocalDateTime.now());
 
+        user.setBalance(user.getBalance() - request.getAmount());
+        authService.save(user);
+
         Position savedPosition = positionRepository.save(position);
 
         return ResponseEntity.ok(Map.of(
@@ -137,7 +155,9 @@ public class MarketController {
                 "marketId", savedPosition.getMarket().getId(),
                 "userId", savedPosition.getUserId(),
                 "positionType", savedPosition.getPositionType(),
-                "amount", savedPosition.getAmount()));
+                "amount", savedPosition.getAmount(),
+                "amount", savedPosition.getAmount(),
+                "balance", user.getBalance()));                
     }
 
     /**

--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -159,9 +159,13 @@ public class MarketController {
                 .map(position -> Map.<String, Object>of(
                         "positionId", position.getId(),
                         "marketId", position.getMarket().getId(),
+                        "marketTitle", position.getMarket().getTitle(),
+                        "marketStatus", position.getMarket().getStatus(),
+                        "marketResult", position.getMarket().getResult() != null ? position.getMarket().getResult() : "PENDING",                        
                         "userId", position.getUserId(),
                         "positionType", position.getPositionType(),
                         "amount", position.getAmount(),
+                        "positionResult", position.getResult() != null ? position.getResult() : "PENDING",
                         "createdAt", position.getCreatedAt().toString()
                 ))
                 .toList();

--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -8,6 +8,7 @@ import com.pms.backend.repository.MarketRepository;
 import com.pms.backend.repository.PositionRepository;
 import com.pms.backend.service.AuthService;
 import com.pms.backend.service.OddsService;
+import com.pms.backend.service.PositionService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @RestController
@@ -26,16 +28,19 @@ public class MarketController {
     private final PositionRepository positionRepository;
     private final OddsService oddsService;
     private final AuthService authService;
+    private final PositionService positionService;
 
     public MarketController(
             MarketRepository marketRepository,
             PositionRepository positionRepository,
             OddsService oddsService,
-            AuthService authService) {
+            AuthService authService,
+            PositionService positionService) {
         this.marketRepository = marketRepository;
         this.positionRepository = positionRepository;
         this.oddsService = oddsService;
         this.authService = authService;
+        this.positionService = positionService;
     }
 
     /**
@@ -122,10 +127,6 @@ public class MarketController {
             return ResponseEntity.badRequest().body("amount must be greater than 0");
         }
 
-        if (user.getBalance() < request.getAmount()) {
-            return ResponseEntity.badRequest().body("Insufficient balance");
-        }
-
         Optional<Market> marketOptional = marketRepository.findById(request.getMarketId());
         if (marketOptional.isEmpty()) {
             return ResponseEntity.status(404).body("Market not found");
@@ -137,17 +138,21 @@ public class MarketController {
             return ResponseEntity.badRequest().body("Market is not open");
         }
 
-        Position position = new Position();
-        position.setUserId(authenticatedUserId);
-        position.setMarket(market);
-        position.setPositionType(positionType);
-        position.setAmount(request.getAmount());
-        position.setCreatedAt(LocalDateTime.now());
+        Position savedPosition;
+        try {
+            savedPosition = positionService.createPositionForUser(
+                    authenticatedUserId,
+                    request.getMarketId(),
+                    positionType,
+                    request.getAmount()
+            );
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(404).body(e.getMessage());
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
 
-        user.setBalance(user.getBalance() - request.getAmount());
-        authService.save(user);
-
-        Position savedPosition = positionRepository.save(position);
+        User updatedUser = authService.findById(authenticatedUserId);
 
         return ResponseEntity.ok(Map.of(
                 "message", "Position created successfully",
@@ -156,7 +161,7 @@ public class MarketController {
                 "userId", savedPosition.getUserId(),
                 "positionType", savedPosition.getPositionType(),
                 "amount", savedPosition.getAmount(),
-                "balance", user.getBalance()));          
+                "balance", updatedUser.getBalance()));   
     }
 
     /**

--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -156,8 +156,7 @@ public class MarketController {
                 "userId", savedPosition.getUserId(),
                 "positionType", savedPosition.getPositionType(),
                 "amount", savedPosition.getAmount(),
-                "amount", savedPosition.getAmount(),
-                "balance", user.getBalance()));                
+                "balance", user.getBalance()));          
     }
 
     /**

--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -1,11 +1,14 @@
 package com.pms.backend.controller;
 
+import com.pms.backend.controller.MarketController.CreatePositionRequest;
 import com.pms.backend.dto.MarketOdds;
 import com.pms.backend.model.Market;
 import com.pms.backend.model.Position;
 import com.pms.backend.repository.MarketRepository;
 import com.pms.backend.repository.PositionRepository;
 import com.pms.backend.service.OddsService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -84,12 +87,20 @@ public class MarketController {
      * Saves a BTC UP/DOWN position.
      */
     @PostMapping("/position")
-    public ResponseEntity<?> createPosition(@RequestBody CreatePositionRequest request) {
+    public ResponseEntity<?> createPosition(
+            @RequestBody CreatePositionRequest request,
+            HttpServletRequest httpRequest
+    ) {
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("USER_ID") == null) {
+            return ResponseEntity.status(401).body("Not authenticated");
+        }
+
+        Long authenticatedUserId = (Long) session.getAttribute("USER_ID");
         if (request.getMarketId() == null ||
-                request.getUserId() == null ||
                 request.getPositionType() == null ||
                 request.getAmount() == null) {
-            return ResponseEntity.badRequest().body("marketId, userId, positionType and amount are required");
+            return ResponseEntity.badRequest().body("marketId, positionType and amount are required");
         }
 
         String positionType = request.getPositionType().trim().toUpperCase();
@@ -113,7 +124,7 @@ public class MarketController {
         }
 
         Position position = new Position();
-        position.setUserId(request.getUserId());
+        position.setUserId(authenticatedUserId);
         position.setMarket(market);
         position.setPositionType(positionType);
         position.setAmount(request.getAmount());
@@ -132,7 +143,6 @@ public class MarketController {
 
     public static class CreatePositionRequest {
         private Long marketId;
-        private Long userId;
         private String positionType;
         private Double amount;
 
@@ -142,14 +152,6 @@ public class MarketController {
 
         public void setMarketId(Long marketId) {
             this.marketId = marketId;
-        }
-
-        public Long getUserId() {
-            return userId;
-        }
-
-        public void setUserId(Long userId) {
-            this.userId = userId;
         }
 
         public String getPositionType() {

--- a/backend/src/main/java/com/pms/backend/controller/WalletController.java
+++ b/backend/src/main/java/com/pms/backend/controller/WalletController.java
@@ -1,0 +1,54 @@
+package com.pms.backend.controller;
+
+import com.pms.backend.model.User;
+import com.pms.backend.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/wallet")
+public class WalletController {
+
+    private static final double STARTER_CLAIM_AMOUNT = 500.0;
+
+    private final AuthService authService;
+
+    public WalletController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/claim")
+    public ResponseEntity<?> claimStarterCoins(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session == null || session.getAttribute("USER_ID") == null) {
+            return ResponseEntity.status(401).body("Not authenticated");
+        }
+
+        Long userId = (Long) session.getAttribute("USER_ID");
+        User user = authService.findById(userId);
+
+        if (user == null) {
+            return ResponseEntity.status(404).body("User not found");
+        }
+
+        if (user.isStarterClaimed()) {
+            return ResponseEntity.badRequest().body("Starter coins already claimed");
+        }
+
+        user.setBalance(user.getBalance() + STARTER_CLAIM_AMOUNT);
+        user.setStarterClaimed(true);
+        authService.save(user);
+
+        return ResponseEntity.ok(Map.of(
+                "message", "Starter coins claimed successfully",
+                "userId", user.getId(),
+                "balance", user.getBalance(),
+                "starterClaimed", user.isStarterClaimed()
+        ));
+    }
+}

--- a/backend/src/main/java/com/pms/backend/dto/AuthUserResponse.java
+++ b/backend/src/main/java/com/pms/backend/dto/AuthUserResponse.java
@@ -1,0 +1,7 @@
+package com.pms.backend.dto;
+
+public record AuthUserResponse(
+        Long id,
+        String name,
+        String email
+) {}

--- a/backend/src/main/java/com/pms/backend/dto/LoginRequest.java
+++ b/backend/src/main/java/com/pms/backend/dto/LoginRequest.java
@@ -1,0 +1,26 @@
+package com.pms.backend.dto;
+
+public class LoginRequest {
+
+    private String email;
+    private String password;
+
+    public LoginRequest() {
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/pms/backend/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/pms/backend/dto/RegisterRequest.java
@@ -1,0 +1,35 @@
+package com.pms.backend.dto;
+
+public class RegisterRequest {
+
+    private String name;
+    private String email;
+    private String password;
+
+    public RegisterRequest() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/pms/backend/model/Market.java
+++ b/backend/src/main/java/com/pms/backend/model/Market.java
@@ -35,6 +35,9 @@ public class Market {
     @Column(nullable = false)
     private Double endingPrice;
 
+    @Column(nullable = false)
+    private boolean payoutProcessed;
+
     @ManyToOne(optional = false)
     @JoinColumn(name = "market_type_id", nullable = false)
     private MarketType marketType;
@@ -108,6 +111,14 @@ public class Market {
 
     public void setEndingPrice(Double endingPrice) {
         this.endingPrice = endingPrice;
+    }
+
+    public boolean isPayoutProcessed() {
+        return payoutProcessed;
+    }
+
+    public void setPayoutProcessed(boolean payoutProcessed) {
+        this.payoutProcessed = payoutProcessed;
     }
 
     public MarketType getMarketType() {

--- a/backend/src/main/java/com/pms/backend/model/User.java
+++ b/backend/src/main/java/com/pms/backend/model/User.java
@@ -1,0 +1,52 @@
+package com.pms.backend.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    public User() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+}

--- a/backend/src/main/java/com/pms/backend/model/User.java
+++ b/backend/src/main/java/com/pms/backend/model/User.java
@@ -19,6 +19,12 @@ public class User {
     @Column(nullable = false)
     private String passwordHash;
 
+    @Column(nullable = false)
+    private Double balance;
+
+    @Column(nullable = false)
+    private boolean starterClaimed;
+
     public User() {
     }
 
@@ -48,5 +54,21 @@ public class User {
 
     public void setPasswordHash(String passwordHash) {
         this.passwordHash = passwordHash;
+    }
+
+    public Double getBalance() {
+        return balance;
+    }
+
+    public void setBalance(Double balance) {
+        this.balance = balance;
+    }
+
+    public boolean isStarterClaimed() {
+        return starterClaimed;
+    }
+
+    public void setStarterClaimed(boolean starterClaimed) {
+        this.starterClaimed = starterClaimed;
     }
 }

--- a/backend/src/main/java/com/pms/backend/repository/PositionRepository.java
+++ b/backend/src/main/java/com/pms/backend/repository/PositionRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public interface PositionRepository extends JpaRepository<Position, Long> {
     List<Position> findByMarketId(Long marketId);
+    List<Position> findByMarketIdAndResult(Long marketId, String result);
     List<Position> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     @Modifying

--- a/backend/src/main/java/com/pms/backend/repository/PositionRepository.java
+++ b/backend/src/main/java/com/pms/backend/repository/PositionRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public interface PositionRepository extends JpaRepository<Position, Long> {
     List<Position> findByMarketId(Long marketId);
+    List<Position> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     @Modifying
     @Query("UPDATE Position p SET p.result = :result WHERE p.market.id = :marketId AND p.positionType = :positionType")

--- a/backend/src/main/java/com/pms/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/pms/backend/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.pms.backend.repository;
+
+import com.pms.backend.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/com/pms/backend/service/AuthService.java
+++ b/backend/src/main/java/com/pms/backend/service/AuthService.java
@@ -35,6 +35,8 @@ public class AuthService {
         user.setName(request.getName().trim());
         user.setEmail(email);
         user.setPasswordHash(passwordEncoder.encode(request.getPassword()));
+        user.setBalance(0.0);
+        user.setStarterClaimed(false);
 
         User savedUser = userRepository.save(user);
 
@@ -47,6 +49,14 @@ public class AuthService {
 
     public User findByEmail(String email) {
         return userRepository.findByEmail(email.trim().toLowerCase()).orElse(null);
+    }
+
+    public User findById(Long userId) {
+        return userRepository.findById(userId).orElse(null);
+    }
+
+    public User save(User user) {
+        return userRepository.save(user);
     }
 
     public boolean passwordMatches(String rawPassword, String passwordHash) {

--- a/backend/src/main/java/com/pms/backend/service/AuthService.java
+++ b/backend/src/main/java/com/pms/backend/service/AuthService.java
@@ -1,0 +1,63 @@
+package com.pms.backend.service;
+
+import com.pms.backend.dto.AuthUserResponse;
+import com.pms.backend.dto.RegisterRequest;
+import com.pms.backend.model.User;
+import com.pms.backend.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public AuthUserResponse register(RegisterRequest request) {
+        if (request.getName() == null || request.getName().isBlank()
+                || request.getEmail() == null || request.getEmail().isBlank()
+                || request.getPassword() == null || request.getPassword().isBlank()) {
+            throw new IllegalArgumentException("name, email and password are required");
+        }
+
+        String email = request.getEmail().trim().toLowerCase();
+
+        if (userRepository.existsByEmail(email)) {
+            throw new IllegalArgumentException("Email already in use");
+        }
+
+        User user = new User();
+        user.setName(request.getName().trim());
+        user.setEmail(email);
+        user.setPasswordHash(passwordEncoder.encode(request.getPassword()));
+
+        User savedUser = userRepository.save(user);
+
+        return new AuthUserResponse(
+                savedUser.getId(),
+                savedUser.getName(),
+                savedUser.getEmail()
+        );
+    }
+
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email.trim().toLowerCase()).orElse(null);
+    }
+
+    public boolean passwordMatches(String rawPassword, String passwordHash) {
+        return passwordEncoder.matches(rawPassword, passwordHash);
+    }
+
+    public AuthUserResponse toResponse(User user) {
+        return new AuthUserResponse(
+                user.getId(),
+                user.getName(),
+                user.getEmail()
+        );
+    }
+}

--- a/backend/src/main/java/com/pms/backend/service/MarketScheduler.java
+++ b/backend/src/main/java/com/pms/backend/service/MarketScheduler.java
@@ -93,8 +93,8 @@ public class MarketScheduler {
         market.setStatus("CLOSED");
         marketRepository.save(market);
 
-        // Resolve all positions
-        positionService.resolveAllPositionsForMarket(market.getId(), result);
+        // Resolve all positions and process payouts once
+        positionService.resolveMarketAndProcessPayouts(market.getId(), result);
 
         System.out.println("[MarketScheduler] Closed market #" + market.getId()
                 + " | start=" + market.getStartingPrice()
@@ -129,6 +129,7 @@ public class MarketScheduler {
         market.setEndingDate(endingDate);
         market.setStatus("OPEN");
         market.setResult(null);
+        market.setPayoutProcessed(false);
         market.setMarketType(marketType);
 
         Market saved = marketRepository.save(market);

--- a/backend/src/main/java/com/pms/backend/service/MarketScheduler.java
+++ b/backend/src/main/java/com/pms/backend/service/MarketScheduler.java
@@ -27,6 +27,7 @@ import java.util.Optional;
  *   - Do NOT open a new market (next successful tick will open one)
  */
 @Service
+@org.springframework.context.annotation.Profile("!test")
 public class MarketScheduler {
 
     private final MarketRepository marketRepository;

--- a/backend/src/main/java/com/pms/backend/service/PositionService.java
+++ b/backend/src/main/java/com/pms/backend/service/PositionService.java
@@ -110,4 +110,27 @@ public class PositionService {
         // Query 2: Set all incorrect positions to LOSS
         positionRepository.batchUpdatePositionResults(marketId, losingPositionType, "LOSS");
     }
+
+    @Transactional
+    public void resolveMarketAndProcessPayouts(Long marketId, String winningPositionType) {
+        Market market = marketRepository.findById(marketId)
+                .orElseThrow(() -> new NoSuchElementException("Market not found"));
+
+        if (market.isPayoutProcessed()) {
+            return;
+        }
+
+        resolveAllPositionsForMarket(marketId, winningPositionType);
+
+        List<Position> winningPositions = positionRepository.findByMarketIdAndResult(marketId, "WIN");
+
+        for (Position position : winningPositions) {
+            User user = userRepository.findById(position.getUserId())
+                    .orElseThrow(() -> new NoSuchElementException("User not found"));
+
+            user.setBalance(user.getBalance() + (position.getAmount() * 2));
+        }
+
+        market.setPayoutProcessed(true);
+    }
 }

--- a/backend/src/main/java/com/pms/backend/service/PositionService.java
+++ b/backend/src/main/java/com/pms/backend/service/PositionService.java
@@ -2,21 +2,33 @@ package com.pms.backend.service;
 
 import com.pms.backend.model.Market;
 import com.pms.backend.model.Position;
+import com.pms.backend.model.User;
+import com.pms.backend.repository.MarketRepository;
 import com.pms.backend.repository.PositionRepository;
+import com.pms.backend.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
 public class PositionService {
 
     private final PositionRepository positionRepository;
+    private final UserRepository userRepository;
+    private final MarketRepository marketRepository;
 
-    public PositionService(PositionRepository positionRepository) {
+    public PositionService(
+            PositionRepository positionRepository,
+            UserRepository userRepository,
+            MarketRepository marketRepository
+    ) {
         this.positionRepository = positionRepository;
+        this.userRepository = userRepository;
+        this.marketRepository = marketRepository;        
     }
 
     /**
@@ -33,6 +45,34 @@ public class PositionService {
         }
 
         return positionRepository.save(positionDetails);
+    }
+
+    @Transactional
+    public Position createPositionForUser(Long userId, Long marketId, String positionType, Double amount) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("User not found"));
+
+        Market market = marketRepository.findById(marketId)
+                .orElseThrow(() -> new NoSuchElementException("Market not found"));
+
+        if (!"OPEN".equals(market.getStatus())) {
+            throw new IllegalStateException("Market is not open");
+        }
+
+        if (user.getBalance() < amount) {
+            throw new IllegalArgumentException("Insufficient balance");
+        }
+
+        user.setBalance(user.getBalance() - amount);
+
+        Position position = new Position();
+        position.setUserId(userId);
+        position.setMarket(market);
+        position.setPositionType(positionType);
+        position.setAmount(amount);
+        position.setCreatedAt(LocalDateTime.now());
+
+        return positionRepository.save(position);
     }
 
     /**

--- a/backend/src/main/resources/application.properties.example
+++ b/backend/src/main/resources/application.properties.example
@@ -15,3 +15,9 @@ spring.sql.init.mode=always
 # Bybit API
 bybit.api.key=your_bybit_api_key
 bybit.api.secret=your_bybit_api_secret
+
+# Ensure data.sql runs AFTER Hibernate creates tables (needed for initial seed data)
+spring.jpa.defer-datasource-initialization=true
+
+# Always run SQL initialization scripts (data.sql) on startup
+spring.sql.init.mode=always

--- a/backend/src/test/java/com/pms/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/pms/backend/BackendApplicationTests.java
@@ -2,11 +2,12 @@ package com.pms.backend;
 
 import com.pms.backend.model.Market;
 import com.pms.backend.model.MarketType;
+import com.pms.backend.model.User;
 import com.pms.backend.repository.MarketRepository;
 import com.pms.backend.repository.MarketTypeRepository;
 import com.pms.backend.repository.PositionRepository;
 import com.pms.backend.repository.UserRepository;
-
+import com.pms.backend.service.PositionService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,6 +45,9 @@ class BackendApplicationTests {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private PositionService positionService;
+
     private Long openMarketId;
 
     @BeforeEach
@@ -68,6 +72,7 @@ class BackendApplicationTests {
         market.setEndingDate(LocalDateTime.now().plusMinutes(5));
         market.setStatus("OPEN");
         market.setEndingPrice(50000.0);
+		market.setPayoutProcessed(false);
         market.setMarketType(marketType);
         market = marketRepository.save(market);
 
@@ -163,5 +168,59 @@ class BackendApplicationTests {
                                 }
                                 """.formatted(openMarketId)))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void winningPositionGetsPaidOutOnlyOnce() throws Exception {
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "winner",
+                                  "email": "winner@test.com",
+                                  "password": "123456"
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "winner@test.com",
+                                  "password": "123456"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
+
+        mockMvc.perform(post("/api/wallet/claim")
+                        .session(session))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/position")
+                        .session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "marketId": %d,
+                                  "positionType": "UP",
+                                  "amount": 100
+                                }
+                                """.formatted(openMarketId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.balance").value(400.0));
+
+        positionService.resolveMarketAndProcessPayouts(openMarketId, "UP");
+
+        User userAfterFirstPayout = userRepository.findByEmail("winner@test.com").orElseThrow();
+        org.junit.jupiter.api.Assertions.assertEquals(600.0, userAfterFirstPayout.getBalance());
+
+        positionService.resolveMarketAndProcessPayouts(openMarketId, "UP");
+
+        User userAfterSecondPayoutAttempt = userRepository.findByEmail("winner@test.com").orElseThrow();
+        org.junit.jupiter.api.Assertions.assertEquals(600.0, userAfterSecondPayoutAttempt.getBalance());
     }
 }

--- a/backend/src/test/java/com/pms/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/pms/backend/BackendApplicationTests.java
@@ -111,6 +111,13 @@ class BackendApplicationTests {
 
         MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
 
+        mockMvc.perform(post("/api/wallet/claim")
+                        .session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(2))
+                .andExpect(jsonPath("$.balance").value(500.0))
+                .andExpect(jsonPath("$.starterClaimed").value(true));
+
         mockMvc.perform(post("/api/position")
                         .session(session)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -126,7 +133,8 @@ class BackendApplicationTests {
                 .andExpect(jsonPath("$.userId").value(2))
                 .andExpect(jsonPath("$.marketId").value(openMarketId))
                 .andExpect(jsonPath("$.positionType").value("UP"))
-                .andExpect(jsonPath("$.amount").value(10.0));
+                .andExpect(jsonPath("$.amount").value(10.0))
+                .andExpect(jsonPath("$.balance").value(490.0));
 
         mockMvc.perform(get("/api/positions/me")
                         .session(session))

--- a/backend/src/test/java/com/pms/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/pms/backend/BackendApplicationTests.java
@@ -1,15 +1,139 @@
 package com.pms.backend;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import com.pms.backend.model.Market;
+import com.pms.backend.model.MarketType;
+import com.pms.backend.repository.MarketRepository;
+import com.pms.backend.repository.MarketTypeRepository;
+import com.pms.backend.repository.PositionRepository;
+import com.pms.backend.repository.UserRepository;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 @SpringBootTest
+@AutoConfigureMockMvc
 @ActiveProfiles("test")
 class BackendApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    private MockMvc mockMvc;
 
+    @Autowired
+    private PositionRepository positionRepository;
+
+    @Autowired
+    private MarketRepository marketRepository;
+
+    @Autowired
+    private MarketTypeRepository marketTypeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Long openMarketId;
+
+    @BeforeEach
+    void setUp() {
+        positionRepository.deleteAll();
+        marketRepository.deleteAll();
+        marketTypeRepository.deleteAll();
+        userRepository.deleteAll();
+
+        MarketType marketType = new MarketType();
+        marketType.setTicker("BTCUSDT");
+        marketType.setApi("BYBIT");
+        marketType.setEnabled(true);
+        marketType.setCreateDate(LocalDateTime.now());
+        marketType = marketTypeRepository.save(marketType);
+
+        Market market = new Market();
+        market.setTitle("BTC 5 Minute UP or DOWN");
+        market.setCreatedAt(LocalDateTime.now());
+        market.setStartingPrice(50000.0);
+        market.setStartingDate(LocalDateTime.now());
+        market.setEndingDate(LocalDateTime.now().plusMinutes(5));
+        market.setStatus("OPEN");
+        market.setEndingPrice(50000.0);
+        market.setMarketType(marketType);
+        market = marketRepository.save(market);
+
+        openMarketId = market.getId();
+    }
+
+    @Test
+    void authenticatedUserCannotSpoofPositionOwnershipAndCanReadOwnPositions() throws Exception {
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "user1",
+                                  "email": "user1@test.com",
+                                  "password": "123456"
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "user2",
+                                  "email": "user2@test.com",
+                                  "password": "123456"
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "user2@test.com",
+                                  "password": "123456"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
+
+        mockMvc.perform(post("/api/position")
+                        .session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "marketId": %d,
+                                  "userId": 1,
+                                  "positionType": "UP",
+                                  "amount": 10
+                                }
+                                """.formatted(openMarketId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(2))
+                .andExpect(jsonPath("$.marketId").value(openMarketId))
+                .andExpect(jsonPath("$.positionType").value("UP"))
+                .andExpect(jsonPath("$.amount").value(10.0));
+
+        mockMvc.perform(get("/api/positions/me")
+                        .session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].userId").value(2))
+                .andExpect(jsonPath("$[0].marketId").value(openMarketId))
+                .andExpect(jsonPath("$[0].positionType").value("UP"))
+                .andExpect(jsonPath("$[0].amount").value(10.0));
+    }
 }

--- a/backend/src/test/java/com/pms/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/pms/backend/BackendApplicationTests.java
@@ -136,4 +136,24 @@ class BackendApplicationTests {
                 .andExpect(jsonPath("$[0].positionType").value("UP"))
                 .andExpect(jsonPath("$[0].amount").value(10.0));
     }
+
+    @Test
+    void unauthenticatedUserCannotReadOwnPositions() throws Exception {
+        mockMvc.perform(get("/api/positions/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticatedUserCannotCreatePosition() throws Exception {
+        mockMvc.perform(post("/api/position")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "marketId": %d,
+                                  "positionType": "UP",
+                                  "amount": 10
+                                }
+                                """.formatted(openMarketId)))
+                .andExpect(status().isForbidden());
+    }
 }


### PR DESCRIPTION
## Summary
Adds a basic wallet flow on top of session-based auth.

## Included
- added `balance` and `starterClaimed` to `User`
- added `POST /api/wallet/claim` for one-time 500 coin starter claim
- extended `GET /api/auth/me` to return wallet state
- integrated balance check and deduction into `POST /api/position`

## Verified
- register/login still work
- starter claim works once
- `/api/auth/me` returns wallet state
- creating a position reduces balance
- insufficient balance is rejected

## Notes
Current scope only covers claim + deduction. Payout/settlement and wallet history are not included yet.