### PR TITLE
fix: add allowCredentials(true) to CORS config for session-based requests

### DIFF
--- a/backend/src/main/java/com/pms/backend/config/CorsConfig.java
+++ b/backend/src/main/java/com/pms/backend/config/CorsConfig.java
@@ -12,6 +12,7 @@ public class CorsConfig implements WebMvcConfigurer {
         registry.addMapping("/api/**")
                 .allowedOrigins("http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*");
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 }


### PR DESCRIPTION
Summary

Enable CORS credentials support for frontend requests.

Changes
Added allowCredentials(true) to CORS configuration

Why

Frontend uses credentials: "include" for session-based requests (auth, position submit).
Without this, browser blocks requests due to missing Access-Control-Allow-Credentials.

Result
POST /api/position works with session cookies
Frontend can communicate with backend without CORS errors