### PR TITLE
feat(fe): add wallet claim flow, market resolution UI and selected market refresh

### DIFF
--- a/backend/src/main/java/com/pms/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/pms/backend/controller/MarketController.java
@@ -90,6 +90,33 @@ public class MarketController {
         return ResponseEntity.ok(List.of(btcMarket));
     }
 
+    @GetMapping("/markets/{id}")
+    public ResponseEntity<?> getMarketById(@PathVariable Long id) {
+        Optional<Market> marketOptional = marketRepository.findById(id);
+
+        if (marketOptional.isEmpty()) {
+            return ResponseEntity.status(404).body("Market not found");
+        }
+
+        Market market = marketOptional.get();
+        MarketOdds odds = oddsService.calculateOdds(market.getId());
+
+        Map<String, Object> btcMarket = new java.util.LinkedHashMap<>();
+        btcMarket.put("id", market.getId());
+        btcMarket.put("title", market.getTitle());
+        btcMarket.put("pair", "BTCUSDT");
+        btcMarket.put("startingPrice", market.getStartingPrice());
+        btcMarket.put("endingPrice", market.getEndingPrice());
+        btcMarket.put("startingDate", market.getStartingDate().toString());
+        btcMarket.put("endingDate", market.getEndingDate().toString());
+        btcMarket.put("status", market.getStatus());
+        btcMarket.put("result", market.getResult());
+        btcMarket.put("yesProbability", odds.upProbability());
+        btcMarket.put("noProbability", odds.downProbability());
+
+        return ResponseEntity.ok(btcMarket);
+    }
+
     /**
      * POST /api/position
      * Saves a BTC UP/DOWN position.

--- a/backend/src/main/java/com/pms/backend/service/MarketScheduler.java
+++ b/backend/src/main/java/com/pms/backend/service/MarketScheduler.java
@@ -77,12 +77,18 @@ public class MarketScheduler {
      */
     @Scheduled(fixedRate = 3000)
     public void updateOpenMarketPrice() {
-        Optional<Market> openMarket = marketRepository.findByStatus("OPEN");
+        System.out.println("[MarketScheduler] Live price update job running...");
+
+        Optional<Market> openMarket = marketRepository.findTopByStatusOrderByIdDesc("OPEN");
+        System.out.println("[MarketScheduler] OPEN market found: " + openMarket.isPresent());
+
         if (openMarket.isEmpty()) {
             return;
         }
 
         Double currentPrice = bybitApiService.marketOrderPrice();
+        System.out.println("[MarketScheduler] Live Bybit price: " + currentPrice);
+
         if (currentPrice == null) {
             System.err.println("[MarketScheduler] Bybit API down — skipping live price update.");
             return;
@@ -90,11 +96,14 @@ public class MarketScheduler {
 
         Market market = openMarket.get();
         market.setEndingPrice(currentPrice);
-        marketRepository.save(market);
+        Market saved = marketRepository.save(market);
+
+        System.out.println("[MarketScheduler] Updated market #" + saved.getId()
+                + " endingPrice=" + saved.getEndingPrice());
     }
 
     private void closeCurrentMarket() {
-        Optional<Market> openMarket = marketRepository.findByStatus("OPEN");
+        Optional<Market> openMarket = marketRepository.findTopByStatusOrderByIdDesc("OPEN");
         if (openMarket.isEmpty()) {
             System.out.println("[MarketScheduler] No OPEN market to close.");
             return;

--- a/backend/src/main/java/com/pms/backend/service/MarketScheduler.java
+++ b/backend/src/main/java/com/pms/backend/service/MarketScheduler.java
@@ -68,6 +68,31 @@ public class MarketScheduler {
         openNewMarket();
     }
 
+
+    /**
+     * Updates the current OPEN market price while the market is still active.
+     *
+     * This keeps frontend "Current Price" live because FE polling can only show
+     * updated values if the backend updates endingPrice before market close.
+     */
+    @Scheduled(fixedRate = 3000)
+    public void updateOpenMarketPrice() {
+        Optional<Market> openMarket = marketRepository.findByStatus("OPEN");
+        if (openMarket.isEmpty()) {
+            return;
+        }
+
+        Double currentPrice = bybitApiService.marketOrderPrice();
+        if (currentPrice == null) {
+            System.err.println("[MarketScheduler] Bybit API down — skipping live price update.");
+            return;
+        }
+
+        Market market = openMarket.get();
+        market.setEndingPrice(currentPrice);
+        marketRepository.save(market);
+    }
+
     private void closeCurrentMarket() {
         Optional<Market> openMarket = marketRepository.findByStatus("OPEN");
         if (openMarket.isEmpty()) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { MarketsPage } from "./pages/MarketsPage";
 import { fetchMe, logout, type AuthUser } from "./api/auth";
 import { AuthModal } from "./components/AuthModal";
+import { WalletPanel } from "./components/WalletPanel";
 
 function App() {
   const [user, setUser] = useState<AuthUser | null>(null);
@@ -18,6 +19,8 @@ function App() {
             id: me.userId,
             name: "",
             email: "",
+            balance: me.balance,
+            starterClaimed: me.starterClaimed,            
           });
         }
       } catch (error) {
@@ -79,7 +82,13 @@ function App() {
           )}
         </header>
 
-        <MarketsPage user={user} onAuthenticated={setUser} />
+        {user && <WalletPanel user={user} onUserUpdated={setUser} />}
+
+        <MarketsPage
+          user={user}
+          onAuthenticated={setUser}
+          onUserUpdated={setUser}
+        />
       </div>
       {showAuth && (
         <AuthModal

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,35 @@ function App() {
     checkSession();
   }, []);
 
+  useEffect(() => {
+    if (!user) return;
+
+    const interval = window.setInterval(async () => {
+      try {
+        const me = await fetchMe();
+
+        if (!me) {
+          setUser(null);
+          return;
+        }
+
+        setUser((currentUser) => {
+          if (!currentUser) return null;
+
+          return {
+            ...currentUser,
+            balance: me.balance,
+            starterClaimed: me.starterClaimed,
+          };
+        });
+      } catch (error) {
+        console.error(error);
+      }
+    }, 3000);
+
+    return () => window.clearInterval(interval);
+  }, [user]);
+
   async function handleLogout() {
     try {
       await logout();

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -2,10 +2,14 @@ export type AuthUser = {
   id: number;
   name: string;
   email: string;
+  balance: number;
+  starterClaimed: boolean;  
 };
 
 export type MeResponse = {
   userId: number;
+  balance: number;
+  starterClaimed: boolean;  
   name?: string;
   email?: string;
 };
@@ -33,7 +37,13 @@ export async function register(payload: RegisterPayload): Promise<AuthUser> {
 
   if (!response.ok) throw new Error(await response.text());
 
-  return response.json();
+  const user = await response.json();
+
+  return {
+    ...user,
+    balance: 0,
+    starterClaimed: false,
+  };
 }
 
 export async function login(payload: LoginPayload): Promise<AuthUser> {
@@ -46,7 +56,14 @@ export async function login(payload: LoginPayload): Promise<AuthUser> {
 
   if (!response.ok) throw new Error(await response.text());
 
-  return response.json();
+  const user = await response.json();
+  const me = await fetchMe();
+
+  return {
+    ...user,
+    balance: me?.balance ?? 0,
+    starterClaimed: me?.starterClaimed ?? false,
+  };
 }
 
 export async function fetchMe(): Promise<MeResponse | null> {

--- a/frontend/src/api/markets.ts
+++ b/frontend/src/api/markets.ts
@@ -51,3 +51,38 @@ export async function fetchMarkets(): Promise<Market[]> {
     },
   );
 }
+
+export async function fetchMarketById(id: number): Promise<Market> {
+  const response = await fetch(
+    `${import.meta.env.VITE_API_BASE_URL}/markets/${id}`,
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch market");
+  }
+
+  const {
+    title,
+    pair,
+    yesProbability,
+    status,
+    startingDate,
+    startingPrice,
+    endingPrice,
+    endingDate,
+    result,
+  }: BackendMarket = await response.json();
+
+  return {
+    id,
+    title,
+    description: `Will ${pair} price be higher in 5 minutes?`,
+    probability: yesProbability,
+    status,
+    startPrice: startingPrice,
+    endingPrice,
+    createdAt: startingDate,
+    endsAt: endingDate,
+    result,
+  };
+}

--- a/frontend/src/api/position.ts
+++ b/frontend/src/api/position.ts
@@ -4,6 +4,7 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export type SubmitPositionPayload = {
   marketId: number;
+  userId: number;
   positionType: PositionSide;
   amount: number;
 };

--- a/frontend/src/api/wallet.ts
+++ b/frontend/src/api/wallet.ts
@@ -1,0 +1,21 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export type ClaimStarterResponse = {
+  message: string;
+  userId: number;
+  balance: number;
+  starterClaimed: boolean;
+};
+
+export async function claimStarterCoins(): Promise<ClaimStarterResponse> {
+  const response = await fetch(`${API_BASE_URL}/wallet/claim`, {
+    method: "POST",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  return response.json();
+}

--- a/frontend/src/components/PositionForm.tsx
+++ b/frontend/src/components/PositionForm.tsx
@@ -3,16 +3,34 @@ import type { PositionSide } from "../types/market";
 type Props = {
   selectedPosition: PositionSide | null;
   onSelect: (side: PositionSide) => void;
+  amount: number;
+  onAmountChange: (value: number) => void;  
   disabled?: boolean;
 };
 
 export function PositionForm({
   selectedPosition,
   onSelect,
+  amount,
+  onAmountChange,  
   disabled = false,
 }: Props) {
   return (
-    <div className="mt-6 flex gap-3">
+    <div className="mt-6 space-y-4">
+      <div>
+        <label className="text-sm text-text-secondary">Amount</label>
+        <input
+          type="number"
+          min={1}
+          step={1}
+          value={amount}
+          onChange={(event) => onAmountChange(Number(event.target.value))}
+          disabled={disabled}
+          className="mt-1 w-full rounded-xl border border-border bg-bg px-4 py-3 text-sm outline-none focus:border-borderHover disabled:cursor-not-allowed disabled:opacity-50"
+        />
+      </div>
+
+      <div className="flex gap-3">
       <button
         type="button"
         onClick={() => onSelect("UP")}
@@ -54,6 +72,7 @@ export function PositionForm({
       >
         NO
       </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ResultPanel.tsx
+++ b/frontend/src/components/ResultPanel.tsx
@@ -1,34 +1,81 @@
 import type { PositionSide } from "../types/market";
+import { FaArrowRight, FaCheckCircle, FaTimesCircle } from "react-icons/fa";
 
 type ResultPanelProps = {
   result: PositionSide | null;
   selectedPosition: PositionSide | null;
+  finalPrice?: number;
+  marketTitle?: string;
+  showGoToLiveMarket?: boolean;
+  onGoToLiveMarket?: () => void;  
 };
 
-function getDisplayLabel(side: PositionSide): "YES" | "NO" {
-  return side === "UP" ? "YES" : "NO";
+function getDisplayLabel(side: PositionSide): "Up" | "Down" {
+  return side === "UP" ? "Up" : "Down";
 }
 
-export function ResultPanel({ result, selectedPosition }: ResultPanelProps) {
+export function ResultPanel({
+  result,
+  selectedPosition,
+  finalPrice,
+  marketTitle,
+  showGoToLiveMarket = false,
+  onGoToLiveMarket,
+}: ResultPanelProps) {
   if (!result) return null;
 
   const userWon = selectedPosition === result;
 
   return (
-    <div className="mt-6 rounded-2xl border border-border bg-surface p-4">
-      <p className="text-sm text-text-secondary">Result</p>
+    <div className="mt-6 rounded-2xl border border-border bg-surface p-6">
+      <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div className="flex-1">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-bg md:mx-0">
+            {userWon ? (
+              <FaCheckCircle className="text-4xl text-success" />
+            ) : (
+              <FaTimesCircle className="text-4xl text-danger" />
+            )}
+          </div>
 
-      <p className="mt-2 text-lg font-semibold text-text-primary">
-        Market resolved: {getDisplayLabel(result)}
-      </p>
+          <p className="mt-5 text-center text-3xl font-semibold text-text-primary md:text-left">
+            Outcome: {getDisplayLabel(result)}
+          </p>
 
-      {selectedPosition && (
-        <p
-          className={`mt-2 text-sm ${userWon ? "text-success" : "text-danger"}`}
-        >
-          {userWon ? "You predicted correctly" : "Your prediction was wrong"}
-        </p>
-      )}
+          {marketTitle && (
+            <p className="mt-3 text-center text-sm text-text-secondary md:text-left">
+              {marketTitle}
+            </p>
+          )}
+
+          {typeof finalPrice === "number" && (
+            <p className="mt-2 text-center text-sm text-text-secondary md:text-left">
+              Final price: ${finalPrice.toFixed(2)}
+            </p>
+          )}
+
+          {selectedPosition && (
+            <p
+              className={`mt-4 text-center text-sm font-medium md:text-left ${
+                userWon ? "text-success" : "text-danger"
+              }`}
+            >
+              {userWon ? "You won this market." : "You lost this market."}
+            </p>
+          )}
+        </div>
+
+        {showGoToLiveMarket && (
+          <button
+            type="button"
+            onClick={onGoToLiveMarket}
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-bg px-5 py-3 text-sm font-semibold text-text-primary transition hover:border-borderHover hover:bg-surface-hover"
+          >
+            Go to live market
+            <FaArrowRight className="text-xs" />
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/WalletPanel.tsx
+++ b/frontend/src/components/WalletPanel.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import type { AuthUser } from "../api/auth";
+import { claimStarterCoins } from "../api/wallet";
+
+type Props = {
+  user: AuthUser;
+  onUserUpdated: (user: AuthUser) => void;
+};
+
+export function WalletPanel({ user, onUserUpdated }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleClaim() {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const result = await claimStarterCoins();
+
+      onUserUpdated({
+        ...user,
+        balance: result.balance,
+        starterClaimed: result.starterClaimed,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to claim starter coins");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="mb-8 rounded-2xl border border-border bg-surface p-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-bold text-text-primary">Wallet</h2>
+          <p className="mt-1 text-sm text-text-secondary">
+            Current balance: <span className="font-semibold text-text-primary">{user.balance}</span>
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleClaim}
+          disabled={loading || user.starterClaimed}
+          className="cursor-pointer rounded-xl bg-blue-500 px-4 py-3 text-sm font-semibold text-white transition hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {user.starterClaimed
+            ? "Starter claimed"
+            : loading
+              ? "Claiming..."
+              : "Claim 500"}
+        </button>
+      </div>
+
+      {error && <p className="mt-3 text-sm text-danger">{error}</p>}
+    </section>
+  );
+}

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -5,6 +5,7 @@ import { PositionForm } from "../components/PositionForm";
 import { ResultPanel } from "../components/ResultPanel";
 import { FaBitcoin } from "react-icons/fa";
 import { submitPosition } from "../api/position";
+import { fetchMarketById } from "../api/markets";
 import type { AuthUser } from "../api/auth";
 import { AuthModal } from "../components/AuthModal";
 
@@ -64,13 +65,31 @@ export function MarketDetailPage({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [showAuth, setShowAuth] = useState(false);
   const [priceHistory, setPriceHistory] = useState<number[]>([]);
+  const [marketState, setMarketState] = useState(market);
 
   useEffect(() => {
+    setMarketState(market);
+  }, [market]);
+
+  useEffect(() => {    
     setPriceHistory((current) => {
-      const next = [...current, market.endingPrice];
+      const next = [...current, marketState.endingPrice];
       return next.slice(-30);
     });
-  }, [market.endingPrice]);
+  }, [marketState.endingPrice]);
+
+  useEffect(() => {
+    const interval = window.setInterval(async () => {
+      try {
+        const updatedMarket = await fetchMarketById(market.id);
+        setMarketState(updatedMarket);
+      } catch (error) {
+        console.error(error);
+      }
+    }, 3000);
+
+    return () => window.clearInterval(interval);
+  }, [market.id]);
 
   const minPrice = Math.min(...priceHistory);
   const maxPrice = Math.max(...priceHistory);
@@ -147,23 +166,23 @@ export function MarketDetailPage({
 
               <div>
                 <h1 className="text-2xl font-bold leading-tight">
-                  {market.title}
+                  {marketState.title}
                 </h1>
 
                 <p className="mt-0.5 text-sm text-text-secondary/80">
-                  {market.description}
+                  {marketState.description}
                 </p>
               </div>
             </div>
 
             <span
               className={`rounded-full px-3 py-1 text-sm font-semibold ${
-                market.status === "OPEN"
+                marketState.status === "OPEN"
                   ? "bg-success-soft text-success"
                   : "bg-danger-soft text-danger"
               }`}
             >
-              {market.status}
+              {marketState.status}
             </span>
           </div>
 
@@ -171,23 +190,23 @@ export function MarketDetailPage({
             <div className="rounded-xl bg-bg p-4">
               <p className="text-sm text-text-secondary">Start Price</p>
               <p className="mt-1 text-lg font-semibold">
-                ${market.startPrice.toFixed(2)}
+                ${marketState.startPrice.toFixed(2)}
               </p>
             </div>
 
             <div className="rounded-xl bg-bg p-4">
               <p className="text-sm text-text-secondary">Current Price</p>
               <p className="mt-1 text-lg font-semibold">
-                ${market.endingPrice.toFixed(2)}
+                ${marketState.endingPrice.toFixed(2)}
               </p>
             </div>
 
             <div className="rounded-xl bg-bg p-4">
               <p className="text-sm text-text-secondary">Time Left</p>
               <p className="mt-1 text-lg font-semibold">
-                {market.status === "OPEN" ? (
+                {marketState.status === "OPEN" ? (
                   <CountdownTimer
-                    endsAt={market.endsAt}
+                    endsAt={marketState.endsAt}
                     onComplete={onMarketExpired}
                   />
                 ) : (
@@ -269,7 +288,7 @@ export function MarketDetailPage({
             onSelect={handleSelect}
             amount={amount}
             onAmountChange={setAmount}            
-            disabled={market.status !== "OPEN" || isSubmitting}
+            disabled={marketState.status !== "OPEN" || isSubmitting}
           />
 
           {showAuth && (
@@ -301,14 +320,14 @@ export function MarketDetailPage({
           )}
 
           <ResultPanel
-            result={market.result}
+            result={marketState.result}
             selectedPosition={selectedPosition}
-            finalPrice={market.endingPrice}
-            marketTitle={market.title}
+            finalPrice={marketState.endingPrice}
+            marketTitle={marketState.title}
             showGoToLiveMarket={
-              market.status === "CLOSED" &&
+              marketState.status === "CLOSED" &&
               !!liveMarket &&
-              liveMarket.id !== market.id &&
+              liveMarket.id !== marketState.id &&
               liveMarket.status === "OPEN"
             }
             onGoToLiveMarket={onGoToLiveMarket}            

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -29,6 +29,7 @@ export function MarketDetailPage({
   onAuthenticated,
   onUserUpdated,
 }: Props) {
+  const [amount, setAmount] = useState(10);
   const [selectedPosition, setSelectedPosition] = useState<PositionSide | null>(
     null,
   );
@@ -44,6 +45,11 @@ export function MarketDetailPage({
       return;
     }
 
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setSubmitError("Amount must be greater than 0");
+      return;
+    }
+
     try {
       setIsSubmitting(true);
 
@@ -51,7 +57,7 @@ export function MarketDetailPage({
         marketId: market.id,
         userId: user.id,
         positionType: side,
-        amount: 10,
+        amount,
       });
 
       onUserUpdated({
@@ -135,6 +141,8 @@ export function MarketDetailPage({
           <PositionForm
             selectedPosition={selectedPosition}
             onSelect={handleSelect}
+            amount={amount}
+            onAmountChange={setAmount}            
             disabled={market.status !== "OPEN" || isSubmitting}
           />
 

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -21,6 +21,10 @@ function getDisplayLabel(side: PositionSide): "YES" | "NO" {
   return side === "UP" ? "YES" : "NO";
 }
 
+function getAmountColorClass(side: PositionSide): string {
+  return side === "UP" ? "text-success" : "text-danger";
+}
+
 export function MarketDetailPage({
   market,
   onMarketExpired,
@@ -167,7 +171,10 @@ export function MarketDetailPage({
 
           {selectedPosition && !submitError && (
             <p className="mt-2 text-sm text-text-secondary">
-              Selected position: {getDisplayLabel(selectedPosition)}
+              Selected position:{" "}
+              <span className={getAmountColorClass(selectedPosition)}>
+                {getDisplayLabel(selectedPosition)} ${amount}
+              </span>
             </p>
           )}
 

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -15,6 +15,8 @@ type Props = {
   user: AuthUser | null;
   onAuthenticated: (user: AuthUser) => void;
   onUserUpdated: (user: AuthUser) => void;
+  liveMarket: Market | null;
+  onGoToLiveMarket: () => void;  
 };
 
 function getDisplayLabel(side: PositionSide): "YES" | "NO" {
@@ -51,6 +53,8 @@ export function MarketDetailPage({
   user,
   onAuthenticated,
   onUserUpdated,
+  liveMarket,
+  onGoToLiveMarket,  
 }: Props) {
   const [amount, setAmount] = useState(10);
   const [selectedPosition, setSelectedPosition] = useState<PositionSide | null>(
@@ -81,7 +85,7 @@ export function MarketDetailPage({
       const y = clampChartY(100 - ((price - minPrice) / priceRange) * 100);
 
       return `${x},${y}`;
-    })
+    });
 
   const chartPath = buildSmoothPath(chartPoints);
   const areaPath =
@@ -261,7 +265,7 @@ export function MarketDetailPage({
           )}
 
           <PositionForm
-            selectedPosition={selectedPosition}
+            selectedPosition={selectedPosition}         
             onSelect={handleSelect}
             amount={amount}
             onAmountChange={setAmount}            
@@ -299,6 +303,15 @@ export function MarketDetailPage({
           <ResultPanel
             result={market.result}
             selectedPosition={selectedPosition}
+            finalPrice={market.endingPrice}
+            marketTitle={market.title}
+            showGoToLiveMarket={
+              market.status === "CLOSED" &&
+              !!liveMarket &&
+              liveMarket.id !== market.id &&
+              liveMarket.status === "OPEN"
+            }
+            onGoToLiveMarket={onGoToLiveMarket}            
           />
         </div>
       </div>

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Market, PositionSide } from "../types/market";
 import { CountdownTimer } from "../components/CountdownTimer";
 import { PositionForm } from "../components/PositionForm";
@@ -25,6 +25,25 @@ function getAmountColorClass(side: PositionSide): string {
   return side === "UP" ? "text-success" : "text-danger";
 }
 
+function buildSmoothPath(points: string[]): string {
+  if (points.length === 0) return "";
+  if (points.length === 1) return `M ${points[0]}`;
+
+  return points.reduce((path, point, index) => {
+    if (index === 0) return `M ${point}`;
+
+    const [previousX, previousY] = points[index - 1].split(",").map(Number);
+    const [currentX, currentY] = point.split(",").map(Number);
+    const midX = (previousX + currentX) / 2;
+
+    return `${path} C ${midX},${previousY} ${midX},${currentY} ${currentX},${currentY}`;
+  }, "");
+}
+
+function clampChartY(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
 export function MarketDetailPage({
   market,
   onMarketExpired,
@@ -40,7 +59,39 @@ export function MarketDetailPage({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [showAuth, setShowAuth] = useState(false);
+  const [priceHistory, setPriceHistory] = useState<number[]>([]);
 
+  useEffect(() => {
+    setPriceHistory((current) => {
+      const next = [...current, market.endingPrice];
+      return next.slice(-30);
+    });
+  }, [market.endingPrice]);
+
+  const minPrice = Math.min(...priceHistory);
+  const maxPrice = Math.max(...priceHistory);
+  const priceRange = maxPrice - minPrice || 1;
+
+  const chartPoints = priceHistory
+    .map((price, index) => {
+      const x =
+        priceHistory.length === 1
+          ? 0
+          : (index / (priceHistory.length - 1)) * 100;
+      const y = clampChartY(100 - ((price - minPrice) / priceRange) * 100);
+
+      return `${x},${y}`;
+    })
+
+  const chartPath = buildSmoothPath(chartPoints);
+  const areaPath =
+    chartPoints.length > 1
+      ? `${chartPath} L 100,100 L 0,100 Z`
+      : "";
+  const currentPoint = chartPoints.at(-1);
+  const [currentX, currentY] = currentPoint
+    ? currentPoint.split(",").map(Number)
+    : [0, 0];
   async function handleSelect(side: PositionSide) {
     setSubmitError(null);
 
@@ -141,6 +192,73 @@ export function MarketDetailPage({
               </p>
             </div>
           </div>
+
+          {priceHistory.length > 1 && (
+            <div className="mt-6 rounded-xl border border-border bg-bg p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <p className="text-sm font-semibold text-text-primary">
+                  Live Price
+                </p>
+                <p className="text-xs text-text-secondary">
+                  Last {priceHistory.length} updates
+                </p>
+              </div>
+
+              <svg
+                viewBox="0 0 100 100"
+                preserveAspectRatio="none"
+                className="h-44 w-full overflow-hidden"
+              >
+                <defs>
+                  <linearGradient id="priceArea" x1="0" x2="0" y1="0" y2="1">
+                    <stop offset="0%" stopColor="currentColor" stopOpacity="0.18" />
+                    <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+                  </linearGradient>
+                </defs>
+
+                {[20, 50, 80].map((lineY) => (
+                  <line
+                    key={lineY}
+                    x1="0"
+                    x2="100"
+                    y1={lineY}
+                    y2={lineY}
+                    stroke="currentColor"
+                    strokeWidth="0.35"
+                    className="text-border"
+                  />
+                ))}
+
+                <path
+                  d={areaPath}
+                  fill="url(#priceArea)"
+                  className="text-success"
+                />
+
+                <path
+                  d={chartPath}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeWidth="1.8"
+                  className="text-success"
+                />
+
+                <circle
+                  cx={currentX}
+                  cy={currentY}
+                  r="1.6"
+                  fill="currentColor"
+                  className="text-success"
+                />
+              </svg>
+
+              <div className="mt-2 flex justify-between text-xs text-text-secondary">
+                <span>${minPrice.toFixed(2)}</span>
+                <span>${maxPrice.toFixed(2)}</span>
+              </div>
+            </div>
+          )}
 
           <PositionForm
             selectedPosition={selectedPosition}

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -14,6 +14,7 @@ type Props = {
   onPositionSubmitted?: () => void;
   user: AuthUser | null;
   onAuthenticated: (user: AuthUser) => void;
+  onUserUpdated: (user: AuthUser) => void;
 };
 
 function getDisplayLabel(side: PositionSide): "YES" | "NO" {
@@ -26,6 +27,7 @@ export function MarketDetailPage({
   onPositionSubmitted,
   user,
   onAuthenticated,
+  onUserUpdated,
 }: Props) {
   const [selectedPosition, setSelectedPosition] = useState<PositionSide | null>(
     null,
@@ -45,10 +47,16 @@ export function MarketDetailPage({
     try {
       setIsSubmitting(true);
 
-      await submitPosition({
+      const result = await submitPosition({
         marketId: market.id,
+        userId: user.id,
         positionType: side,
         amount: 10,
+      });
+
+      onUserUpdated({
+        ...user,
+        balance: result.balance,
       });
 
       setSelectedPosition(side);

--- a/frontend/src/pages/MarketsPage.tsx
+++ b/frontend/src/pages/MarketsPage.tsx
@@ -44,7 +44,11 @@ export function MarketsPage({
 
         const updated = data.find((m) => m.id === currentSelectedMarket.id);
 
-        return updated ?? data[0];
+        if (updated) {
+          return updated;
+        }
+
+        return currentSelectedMarket;
       });
     } catch (err) {
       setError("Failed to load markets");
@@ -73,6 +77,8 @@ export function MarketsPage({
   }
 
   if (selectedMarket) {
+    const liveMarket = markets[0] ?? null;
+
     return (
       <div>
         <button
@@ -90,6 +96,12 @@ export function MarketsPage({
           user={user}
           onAuthenticated={onAuthenticated}
           onUserUpdated={onUserUpdated}
+          liveMarket={liveMarket}
+          onGoToLiveMarket={() => {
+            if (liveMarket) {
+              setSelectedMarket(liveMarket);
+            }
+          }}          
         />
       </div>
     );

--- a/frontend/src/pages/MarketsPage.tsx
+++ b/frontend/src/pages/MarketsPage.tsx
@@ -9,9 +9,14 @@ import type { AuthUser } from "../api/auth";
 type Props = {
   user: AuthUser | null;
   onAuthenticated: (user: AuthUser) => void;
+  onUserUpdated: (user: AuthUser) => void;
 };
 
-export function MarketsPage({ user, onAuthenticated }: Props) {
+export function MarketsPage({
+  user,
+  onAuthenticated,
+  onUserUpdated,
+}: Props) {
   const [markets, setMarkets] = useState<Market[]>([]);
   const [selectedMarket, setSelectedMarket] = useState<Market | null>(null);
   const [positionsRefreshKey, setPositionsRefreshKey] = useState(0);
@@ -84,6 +89,7 @@ export function MarketsPage({ user, onAuthenticated }: Props) {
           onPositionSubmitted={refreshPositions}
           user={user}
           onAuthenticated={onAuthenticated}
+          onUserUpdated={onUserUpdated}
         />
       </div>
     );


### PR DESCRIPTION
## Summary
- Added wallet state management on frontend
- Implemented initial claim API integration
- Synced wallet balance after claim and position submit
- Added wallet panel UI and session restore
- Added amount input for position submit (replaces fixed 10 per click)
- Added live price chart for open market view
- Added resolved market outcome panel with final price
- Kept resolved market visible until user opens the next live market
- Added live market navigation CTA after market resolution
- Added live wallet balance polling for automatic balance refresh after payout
- Added market detail endpoint for selected market refresh
- Added selected market polling by id so resolved state appears correctly after market rollover

## Changes
- Wallet state handling (init, sync, restore)
- Claim flow integration (starter API)
- Balance updates after user actions
- UI: wallet panel
- UI: amount input for flexible position sizing
- UI: selected position highlight with colored amount
- UI: live price chart with smooth curve and filled area
- UI: resolved market panel with outcome, final price, and CTA
- UX: resolved market stays visible instead of auto-switching immediately
- Wallet state polling every 3 seconds while authenticated
- API: `GET /api/markets/{id}` for fetching a specific market
- FE: selected market detail now refreshes independently from latest market list 

## Why
- Fixed 10 per click was not flexible
- Enables better UX and real usage scenarios
- Prepares system for more advanced wallet logic
- Makes market resolution clearer to the user
- Improves transition from ended market to next live market
- Ensures balance reflects payout automatically without manual refresh
- Fixes stale detail view when the latest market rolls over to a new id

## Notes
- Current implementation is MVP-level
- Further validation and edge cases can be added next
- Backend scheduler resolves market and opens the next one on 5-minute boundary
- Frontend now supports open market view and resolved market view separately
- Latest market list and selected market detail now refresh through separate flows

## Testing
- Claim updates wallet balance
- Position submit updates balance correctly
- Page refresh restores wallet state
- Custom amount input works as expected
- Open market current price updates on frontend
- Live price chart renders during active market
- Resolved market shows outcome and final price
- New live market can be opened via CTA after previous market resolves
- Balance updates automatically after payout while user stays on the page
- Selected market updates from OPEN to CLOSED without requiring manual navigation
- Outcome and final price now appear correctly after market rollover

TODO:
- update API docs for GET /api/markets/{id}
- update README to reflect selected market refresh flow
- document wallet polling and resolved market UI behavior