### PR TITLE
Display live current price for open markets

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/trending-up.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>Market Simulator</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/api/markets.ts
+++ b/frontend/src/api/markets.ts
@@ -7,6 +7,7 @@ type BackendMarket = {
   startingPrice: number;
   endingPrice: number;
   startingDate: string;
+  currentPrice: number;
   endingDate: string;
   status: "OPEN" | "CLOSED";
   yesProbability: number;
@@ -33,6 +34,7 @@ export async function fetchMarkets(): Promise<Market[]> {
       startingDate,
       startingPrice,
       endingPrice,
+      currentPrice,
       endingDate,
       result,
     }) => {
@@ -44,6 +46,7 @@ export async function fetchMarkets(): Promise<Market[]> {
         status,
         startPrice: startingPrice,
         endingPrice,
+        currentPrice,
         createdAt: startingDate,
         endsAt: endingDate,
         result,

--- a/frontend/src/components/MarketCard.tsx
+++ b/frontend/src/components/MarketCard.tsx
@@ -45,7 +45,7 @@ export function MarketCard({ market }: MarketCardProps) {
         <div className="rounded-xl bg-bg p-3">
           <p className="text-xs text-text-secondary">Current Price</p>
           <p className="mt-1 text-sm font-semibold">
-            ${market.endingPrice.toFixed(2)}
+            ${market.currentPrice.toFixed(2)}
           </p>
         </div>
       </div>

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -62,6 +62,11 @@ export function MarketDetailPage({
     }
   }
 
+  const displayPrice =
+    market.status === "OPEN" ? market.currentPrice : market.endingPrice;
+
+  const priceLabel = market.status === "OPEN" ? "Current Price" : "Final Price";
+
   return (
     <section className="min-h-screen bg-bg py-10 text-text-primary">
       <div className="mx-auto max-w-3xl px-4">
@@ -103,9 +108,9 @@ export function MarketDetailPage({
             </div>
 
             <div className="rounded-xl bg-bg p-4">
-              <p className="text-sm text-text-secondary">Current Price</p>
+              <p className="text-sm text-text-secondary">{priceLabel}</p>
               <p className="mt-1 text-lg font-semibold">
-                ${market.endingPrice.toFixed(2)}
+                ${displayPrice.toFixed(2)}
               </p>
             </div>
 

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -9,6 +9,7 @@ export type Market = {
   probability: number;
   status: MarketStatus;
   startPrice: number;
+  currentPrice: number;
   endingPrice: number;
   createdAt: string;
   endsAt: string;


### PR DESCRIPTION
## Summary
Fixes market price display logic in the frontend.

## Changes
- Use `currentPrice` for OPEN markets
- Use `endingPrice` for CLOSED markets
- Update price label dynamically (Current Price / Final Price)

## Why
Previously, the UI always displayed `endingPrice`, which does not update during an open market.
This caused the price to appear static even though live data was available.

Now the UI correctly reflects live market movement and final results.